### PR TITLE
Enable Large File Support (LFS) on 32-bit systems by default

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -27,7 +27,8 @@
 #ifdef __linux__
 #define _XOPEN_SOURCE 600     /* For flockfile() on Linux */
 #endif
-#define _LARGEFILE_SOURCE     /* Enable 64-bit file offsets */
+#define _LARGEFILE_SOURCE     /* For fseeko(), ftello() */
+#define _FILE_OFFSET_BITS 64  /* Use 64-bit file offsets by default */
 #define __STDC_FORMAT_MACROS  /* <inttypes.h> wants this for C++ */
 #define __STDC_LIMIT_MACROS   /* C++ wants that for INT64_MAX */
 #endif


### PR DESCRIPTION
In line with the structure of the existing code, this is done by
adding '#define _FILE_OFFSET_BITS 64' near the top of civetweb.c,
before the various system #includes.

This might not work well if the code is later split up into more
translation units; in that case, it would be better to move the LFS
macros into a separate header file that is included as appropriate.
It may also be more portable to enable LFS via the makefile instead,
for example, by adding something like:

  ifdef WITH_LFS
    CFLAGS += $(shell getconf LFS_CFLAGS)
    LDFLAGS += $(shell getconf LFS_LDFLAGS)
  endif
