### PR TITLE
Unconditionally undef WINDOWS_LEAN_AND_MEAN. This makes things build

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -261,6 +261,10 @@ struct pollfd {
 #include <inttypes.h>
 #include <netdb.h>
 
+#if defined(ANDROID)
+typedef unsigned short int in_port_t;
+#endif
+
 #include <pwd.h>
 #include <unistd.h>
 #include <dirent.h>


### PR DESCRIPTION
again with vc9 and vc10. Don't know about vc11 or vc12.
