### PR TITLE
Make content length available in request_info

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -62,6 +62,8 @@ struct mg_request_info {
     const char *remote_user;    /* Authenticated user, or NULL if no auth
                                    used */
     long remote_ip;             /* Client's IP address */
+    long long content_length;   /* Length (in bytes) of the request body,
+                                   can be -1 if no length was given. */
     int remote_port;            /* Client's port */
     int is_ssl;                 /* 1 if SSL-ed, 0 if not */
     void *user_data;            /* User data pointer passed to mg_start() */

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -6232,6 +6232,7 @@ static void reset_per_request_attributes(struct mg_connection *conn)
     conn->num_bytes_sent = conn->consumed_content = 0;
     conn->status_code = -1;
     conn->must_close = conn->request_len = conn->throttle = 0;
+    conn->request_info.content_length = -1;
 }
 
 static void close_socket_gracefully(struct mg_connection *conn)
@@ -6394,6 +6395,8 @@ static int getreq(struct mg_connection *conn, char *ebuf, size_t ebuf_len)
         if ((cl = get_header(&conn->request_info, "Content-Length")) != NULL) {
             /* Request/response has content length set */
             conn->content_len = strtoll(cl, NULL, 10);
+            /* Publish the content length back to the request info. */
+            conn->request_info.content_length = conn->content_len;
         } else if (!mg_strcasecmp(conn->request_info.request_method, "POST") ||
                    !mg_strcasecmp(conn->request_info.request_method, "PUT")) {
             /* POST or PUT request without content length set */


### PR DESCRIPTION
- given that the content-length header is already parsed, lets make
  it also available in the request_info struct to allow easy access;
- added simple unit test to verify the behavior of the new field.
