### PR TITLE
Suppressing warnings in x64 environment on Windows

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -3216,7 +3216,7 @@ static int read_auth_file(struct file *filep, struct read_auth_file_struct * wor
     char *p;
     int is_authorized = 0;
     struct file fp;
-    int l;
+    size_t l;
 
     /* Loop over passwords file */
     p = (char *) filep->membuf;
@@ -5700,7 +5700,7 @@ static int use_request_handler(struct mg_connection *conn)
         }
 
         /* try for pattern match */
-        if (match_prefix(tmp_rh->uri, tmp_rh->uri_len, uri) > 0) {
+        if (match_prefix(tmp_rh->uri, (int)tmp_rh->uri_len, uri) > 0) {
            return tmp_rh->handler(conn, tmp_rh->cbdata);
         }
 


### PR DESCRIPTION
This commit should be pretty safe, as it's simply warning suppression for the 64-bit Windows platform (Visual Studio 2010, specifically).
