### PR TITLE
Allow client to send POST request

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -600,6 +600,14 @@ CIVETWEB_API struct mg_connection *mg_connect_websocket_client(const char *host,
                                                const char *path, const char *origin,
                                                websocket_data_func data_func, websocket_close_func close_func,
                                                void * user_data);
+
+CIVETWEB_API int mg_printf(struct mg_connection *conn, const char *fmt, ...);
+
+CIVETWEB_API struct mg_connection *mg_connect(const char *host, int port, int use_ssl,
+                                 char *ebuf, size_t ebuf_len);
+
+CIVETWEB_API int mg_getreq(struct mg_connection *conn, char *ebuf, size_t ebuf_len);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -2438,8 +2438,6 @@ static int alloc_vprintf(char **buf, size_t size, const char *fmt, va_list ap)
     return len;
 }
 
-int mg_vprintf(struct mg_connection *conn, const char *fmt, va_list ap);
-
 int mg_vprintf(struct mg_connection *conn, const char *fmt, va_list ap)
 {
     char mem[MG_BUF_LEN], *buf = mem;
@@ -6417,7 +6415,7 @@ void mg_close_connection(struct mg_connection *conn)
     mg_free(conn);
 }
 
-static struct mg_connection *mg_connect(const char *host, int port, int use_ssl,
+struct mg_connection *mg_connect(const char *host, int port, int use_ssl,
                                  char *ebuf, size_t ebuf_len)
 {
     static struct mg_context fake_ctx;
@@ -6472,7 +6470,7 @@ static int is_valid_uri(const char *uri)
     return uri[0] == '/' || (uri[0] == '*' && uri[1] == '\0');
 }
 
-static int getreq(struct mg_connection *conn, char *ebuf, size_t ebuf_len)
+int mg_getreq(struct mg_connection *conn, char *ebuf, size_t ebuf_len)
 {
     const char *cl;
 
@@ -6525,7 +6523,7 @@ struct mg_connection *mg_download(const char *host, int port, int use_ssl,
     } else if (mg_vprintf(conn, fmt, ap) <= 0) {
         snprintf(ebuf, ebuf_len, "%s", "Error sending request");
     } else {
-        getreq(conn, ebuf, ebuf_len);
+        mg_getreq(conn, ebuf, ebuf_len);
     }
     if (ebuf[0] != '\0' && conn != NULL) {
         mg_close_connection(conn);
@@ -6648,7 +6646,7 @@ static void process_new_connection(struct mg_connection *conn)
        to crule42. */
     conn->data_len = 0;
     do {
-        if (!getreq(conn, ebuf, sizeof(ebuf))) {
+        if (!mg_getreq(conn, ebuf, sizeof(ebuf))) {
             send_http_error(conn, 500, "Server Error", "%s", ebuf);
             conn->must_close = 1;
         } else if (!is_valid_uri(conn->request_info.uri)) {


### PR DESCRIPTION
I have a requirement to initiate a POST request from an application using civetweb.  mg_download() could almost be coerced into doing this but it was waiting for a response before sending the data which caused deadlock unless we expected 100-continue (but this did not work through all proxies we tried).

So, I have modified civertweb to expose the mg_connect(), mg_printf() and mg_getreq() functions.  This allows me to use these lower level functions to implement the POST request.

Please feel free to do with this PR as you see fit.
