### PR TITLE
Add OPTIONS method to C++ server class

### DIFF
--- a/include/CivetServer.h
+++ b/include/CivetServer.h
@@ -65,6 +65,14 @@ public:
      */
     virtual bool handleDelete(CivetServer *server, struct mg_connection *conn);
 
+    /**
+     * Callback method for OPTIONS request.
+     *
+     * @param server - the calling server
+     * @param conn - the connection information
+     * @returns true if implemented, false otherwise
+     */
+    virtual bool handleOptions(CivetServer *server, struct mg_connection *conn);
 };
 
 /**

--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -42,6 +42,13 @@ bool CivetHandler::handleDelete(CivetServer *server, struct mg_connection *conn)
     return false;
 }
 
+bool CivetHandler::handleOptions(CivetServer *server, struct mg_connection *conn)
+{
+    UNUSED_PARAMETER(server);
+    UNUSED_PARAMETER(conn);
+    return false;
+}
+
 int CivetServer::requestHandler(struct mg_connection *conn, void *cbdata)
 {
     struct mg_request_info *request_info = mg_get_request_info(conn);
@@ -63,6 +70,8 @@ int CivetServer::requestHandler(struct mg_connection *conn, void *cbdata)
             return handler->handlePut(me, conn) ? 1 : 0;
         } else if (strcmp(request_info->request_method, "DELETE") == 0) {
             return handler->handleDelete(me, conn) ? 1 : 0;
+        } else if (strcmp(request_info->request_method, "OPTIONS") == 0) {
+            return handler->handleOptions(me, conn) ? 1 : 0;
         }
     }
 


### PR DESCRIPTION
I had to modify civertweb to handle the OPTIONS method within the C++ server.  This is to allow my server to correctly handle pre-flight CORS requests.
Please feel free to add it to the product.
