### PR TITLE
Reset data from previous response for new request

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -6312,6 +6312,7 @@ static void reset_per_request_attributes(struct mg_connection *conn)
     conn->status_code = -1;
     conn->must_close = conn->request_len = conn->throttle = 0;
     conn->request_info.content_length = -1;
+    conn->data_len = 0;
 }
 
 static void close_socket_gracefully(struct mg_connection *conn)


### PR DESCRIPTION
If I did multiple getreq() calls on the same response I was getting errors.
Investigation revealed that the previous response was being cached, so I've reset data_len in reset_per_request_attributes().
It works OK for me now.
