### PR TITLE
Added mg_is_context_stopped

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -743,6 +743,16 @@ CIVETWEB_API int mg_get_response(struct mg_connection *conn,
 CIVETWEB_API unsigned mg_check_feature(unsigned feature);
 
 
+/* Get the stopping status of a given civetweb context.
+
+   Return:
+    0: context is running normally
+	1: context is shutting down
+	2: context has stopped
+   -1: Invalid context
+ */
+CIVETWEB_API int mg_is_ctx_stopped(const struct mg_context* ctx)
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -10754,6 +10754,12 @@ struct mg_context *mg_start(const struct mg_callbacks *callbacks,
 	return ctx;
 }
 
+int mg_is_ctx_stopped(const struct mg_context* ctx)
+{
+	if (!ctx) return -1;
+
+	return ctx->stop_flag;
+}
 
 /* Feature check API function */
 unsigned mg_check_feature(unsigned feature)


### PR DESCRIPTION
Long running client code sometimes needs to know when civetweb is
exiting so that it can cleanly abort a long process.