### PR TITLE
Allow parameters to the resource compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ $(BUILD_DIR)/%.o : %.c
 	$(CC) -c $(CFLAGS) $< -o $@
 
 $(BUILD_RESOURCES) : $(WINDOWS_RESOURCES)
-	windres $< $@
+	windres $(WINDRES_FLAGS) $< $@
 
 # This rules is used to keep the code formatted in a reasonable manor
 # For this to work astyle must be installed and in the path


### PR DESCRIPTION
Using Cygwin64, build fails when trying to compile for Windows 32-bit.
'windres' needs to be supplied "-F pe-i386" when building for 32-bit.

My compile commands are:
### for 32-bit
* rm -rf out/; make CC=i686-w64-mingw32-gcc COPT="-static" WINDRES_FLAGS="-F pe-i386"

### for 64-bit
* rm -rf out/; make CC=x86_64-w64-mingw32-gcc COPT="-static" WINDRES_FLAGS="-F pe-x86-64"

Regards,
Shantanu