### PR TITLE
Fixed mg_upload() to work with multiple files.

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -8406,7 +8406,9 @@ int mg_upload(struct mg_connection *conn, const char *destination_dir)
 				memmove(buf, &buf[len - bl], (size_t)bl);
 				len = bl;
 			}
-			n = mg_read(conn, buf + len, sizeof(buf) - ((size_t)(len)));
+			if (!eof) {
+				n = mg_read(conn, buf + len, sizeof(buf) - ((size_t)(len)));
+			}
 		} while (!eof && (n > 0));
 		fclose(fp);
 		if (eof) {


### PR DESCRIPTION
I was having issue with mg_upload with multiple files (in my case I was using two upload files with file size around 8MB each).  In my case the second file that get uploaded will have a bad md5sum compare to the original file (the first file uploaded properly everytime).  I believe the cause of this issue is due to the fact that mg_read() got called without the "len" variable being updated right afterward.  I have put in a simple fix by not calling mg_read when the boundary (the end of first file) is found.

I noticed there is an unit test for multiple files upload, but it is currently ifdef out so I didn't bother to put in the test for this change.