### PR TITLE
Fix redefinition of timespec in VS2015

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -320,6 +320,9 @@ typedef DWORD clockid_t;
 #define CLOCK_REALTIME (2)
 #endif
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#define _TIMESPEC_DEFINED
+#endif
 #ifndef _TIMESPEC_DEFINED
 struct timespec {
 	time_t tv_sec; /* seconds */


### PR DESCRIPTION
VS2015 now defines timespec