### PR TITLE
Adding removeWebSocketHandler

### DIFF
--- a/include/CivetServer.h
+++ b/include/CivetServer.h
@@ -243,6 +243,15 @@ class CIVETWEB_API CivetServer
 	 */
 	void removeHandler(const std::string &uri);
 
+    /**
+     * removeWebSocketHandler(const std::string &)
+     *
+     * Removes a web socket handler.
+     *
+     * @param uri - the exact URL used in addWebSocketHandler().
+     */
+    void removeWebSocketHandler(const std::string &uri);
+
 	/**
 	 * getListeningPorts()
 	 *

--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -288,6 +288,12 @@ CivetServer::removeHandler(const std::string &uri)
 }
 
 void
+CivetServer::removeWebSocketHandler(const std::string &uri)
+{
+    mg_set_websocket_handler(context, uri.c_str(), NULL, NULL, NULL, NULL, NULL);
+}
+
+void
 CivetServer::close()
 {
 	if (context) {


### PR DESCRIPTION
Personally, I would think that using removeHandler() for both kinds of handlers would be nicer instead of having an extra function. What do you think?