### PR TITLE
Refactoring conditional directives for incomplete if conditions.

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -4263,6 +4263,8 @@ interpret_uri(struct mg_connection *conn,   /* in: request (must be valid) */
 #else
 	(void)filename_buf_len; /* unused if NO_FILES is defined */
 #endif
+  int check_match_prefix = 0;
+	int check_match_prefix_script = 0;
 
 	memset(filep, 0, sizeof(*filep));
 	*filename = 0;
@@ -4325,24 +4327,22 @@ interpret_uri(struct mg_connection *conn,   /* in: request (must be valid) */
 	if (mg_stat(conn, filename, filep)) {
 #if !defined(NO_CGI) || defined(USE_LUA) || defined(USE_DUKTAPE)
 		/* File exists. Check if it is a script type. */
-		if (0
 #if !defined(NO_CGI)
-		    || match_prefix(conn->ctx->config[CGI_EXTENSIONS],
-		                    strlen(conn->ctx->config[CGI_EXTENSIONS]),
-		                    filename) > 0
+		check_match_prefix = (check_match_prefix || match_prefix(conn->ctx->config[CGI_EXTENSIONS],
+		                      strlen(conn->ctx->config[CGI_EXTENSIONS]),
+		                      filename) > 0);
 #endif
 #if defined(USE_LUA)
-		    || match_prefix(conn->ctx->config[LUA_SCRIPT_EXTENSIONS],
-		                    strlen(conn->ctx->config[LUA_SCRIPT_EXTENSIONS]),
-		                    filename) > 0
+		check_match_prefix = (check_match_prefix || match_prefix(conn->ctx->config[LUA_SCRIPT_EXTENSIONS],
+		                      strlen(conn->ctx->config[LUA_SCRIPT_EXTENSIONS]),
+		                      filename) > 0);
 #endif
 #if defined(USE_DUKTAPE)
-		    || match_prefix(conn->ctx->config[DUKTAPE_SCRIPT_EXTENSIONS],
-		                    strlen(
-		                        conn->ctx->config[DUKTAPE_SCRIPT_EXTENSIONS]),
-		                    filename) > 0
+		check_match_prefix = (check_match_prefix || match_prefix(conn->ctx->config[DUKTAPE_SCRIPT_EXTENSIONS],
+		                      strlen(conn->ctx->config[DUKTAPE_SCRIPT_EXTENSIONS]),
+		                      filename) > 0);
 #endif
-		    ) {
+		if (check_match_prefix) {
 			/* The request addresses a CGI script or a Lua script. The URI
 			 * corresponds to the script itself (like /path/script.cgi),
 			 * and there is no additional resource path
@@ -4391,25 +4391,25 @@ interpret_uri(struct mg_connection *conn,   /* in: request (must be valid) */
 	for (p = filename + strlen(filename); p > filename + 1; p--) {
 		if (*p == '/') {
 			*p = '\0';
-			if ((0
 #if !defined(NO_CGI)
-			     || match_prefix(conn->ctx->config[CGI_EXTENSIONS],
-			                     strlen(conn->ctx->config[CGI_EXTENSIONS]),
-			                     filename) > 0
+			check_match_prefix_script = (check_match_prefix_script
+				                          || match_prefix(conn->ctx->config[CGI_EXTENSIONS],
+			                            strlen(conn->ctx->config[CGI_EXTENSIONS]),
+			                            filename) > 0);
 #endif
 #if defined(USE_LUA)
-			     || match_prefix(conn->ctx->config[LUA_SCRIPT_EXTENSIONS],
-			                     strlen(
-			                         conn->ctx->config[LUA_SCRIPT_EXTENSIONS]),
-			                     filename) > 0
+			check_match_prefix_script = (check_match_prefix_script
+			                            || match_prefix(conn->ctx->config[LUA_SCRIPT_EXTENSIONS],
+			                            strlen(conn->ctx->config[LUA_SCRIPT_EXTENSIONS]),
+			                            filename) > 0);
 #endif
 #if defined(USE_DUKTAPE)
-			     || match_prefix(
-			            conn->ctx->config[DUKTAPE_SCRIPT_EXTENSIONS],
-			            strlen(conn->ctx->config[DUKTAPE_SCRIPT_EXTENSIONS]),
-			            filename) > 0
+			check_match_prefix_script= (check_match_prefix_script
+			                           || match_prefix(conn->ctx->config[DUKTAPE_SCRIPT_EXTENSIONS],
+			                           strlen(conn->ctx->config[DUKTAPE_SCRIPT_EXTENSIONS]),
+			                           filename) > 0);
 #endif
-			     ) && mg_stat(conn, filename, filep)) {
+			  if (check_match_prefix_script && mg_stat(conn, filename, filep)) {
 				/* Shift PATH_INFO block one character right, e.g.
 				 * "/x.cgi/foo/bar\x00" => "/x.cgi\x00/foo/bar\x00"
 				 * conn->path_info is pointing to the local variable "path"
@@ -11396,6 +11396,7 @@ worker_thread_run(void *thread_func_param)
 #if defined(MG_LEGACY_INTERFACE)
 	uint32_t addr;
 #endif
+int check_ssl;
 
 	mg_set_thread_name("worker");
 
@@ -11452,11 +11453,11 @@ worker_thread_run(void *thread_func_param)
 
 			conn->request_info.is_ssl = conn->client.is_ssl;
 
-			if (!conn->client.is_ssl
+			check_ssl = (!conn->client.is_ssl);
 #ifndef NO_SSL
-			    || sslize(conn, conn->ctx->ssl_ctx, SSL_accept)
+			check_ssl = (check_ssl || sslize(conn, conn->ctx->ssl_ctx, SSL_accept));
 #endif
-			        ) {
+			if (check_ssl) {
 
 
 				process_new_connection(conn);


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

* [Linux kernel coding style](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892)
* [Living in the #ifdef Hell](https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/)

It might improve code understanding, maintainability and error-proneness.