### PR TITLE
Adapt IPv6/Websocket building/checking in embedded_c example  

### DIFF
--- a/examples/embedded_c/Makefile
+++ b/examples/embedded_c/Makefile
@@ -27,7 +27,7 @@ $(PROG): $(CIVETWEB_LIB) $(SRC)
 	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(SRC) $(CIVETWEB_LIB) $(LIBS)
 
 $(CIVETWEB_LIB):
-	$(MAKE) -C $(TOP) clean lib
+	$(MAKE) -C $(TOP) WITH_IPV6=1 WITH_WEBSOCKET=1 clean lib
 	cp $(TOP)/$(CIVETWEB_LIB) .
 
 clean:

--- a/examples/embedded_c/embedded_c.c
+++ b/examples/embedded_c/embedded_c.c
@@ -343,7 +343,7 @@ main(int argc, char *argv[])
 #ifdef USE_IPV6
 	if (!mg_check_feature(8)) {
 		fprintf(stderr,
-		        "Error: Embedded example built with websocket support, "
+		        "Error: Embedded example built with IPv6 support, "
 		        "but civetweb library build without.\n");
 		err = 1;
 	}


### PR DESCRIPTION
- The example states that the civetweb library has not been build with websocket support although it actually checks for Ipv6 support. 
- in case the civetweb library has not been build yet. The execution of 'make' in the embedded_c example fails because the civetweb library is built without IPv6 and Websocket support.