### PR TITLE
Add custom authorization handler

### DIFF
--- a/include/CivetServer.h
+++ b/include/CivetServer.h
@@ -98,6 +98,31 @@ class CIVETWEB_API CivetHandler
 };
 
 /**
+ * Basic interface for a URI authorization handler.  Handler implementations
+ * must be reentrant.
+ */
+class CIVETWEB_API CivetAuthHandler
+{
+  public:
+	/**
+	 * Destructor
+	 */
+	virtual ~CivetAuthHandler()
+	{
+	}
+
+	/**
+	 * Callback method for authorization requests. It is up the this handler
+	 * to generate authorization requests.
+	 *
+	 * @param server - the calling server
+	 * @param conn - the connection information
+	 * @returns true if authorization succeeded, false otherwise
+	 */
+	virtual bool authorize(CivetServer *server, struct mg_connection *conn);
+};
+
+/**
  * Basic interface for a websocket handler.  Handlers implementations
  * must be reentrant.
  */
@@ -262,6 +287,34 @@ class CIVETWEB_API CivetServer
 	 * @param uri - the exact URL used in addWebSocketHandler().
 	 */
 	void removeWebSocketHandler(const std::string &uri);
+
+	/**
+	 * addAuthHandler(const std::string &, CivetAuthHandler *)
+	 *
+	 * Adds a URI authorization handler.  If there is existing URI authorization
+	 * handler, it will be replaced with this one.
+	 *
+	 * URI's are ordered and prefix (REST) URI's are supported.
+	 *
+	 * @param uri - URI to match.
+	 * @param handler - authorization handler instance to use.
+	 */
+	void addAuthHandler(const std::string &uri, CivetAuthHandler *handler);
+
+	void
+	addAuthHandler(const std::string &uri, CivetAuthHandler &handler)
+	{
+		addAuthHandler(uri, &handler);
+	}
+
+	/**
+	 * removeAuthHandler(const std::string &)
+	 *
+	 * Removes an authorization handler.
+	 *
+	 * @param uri - the exact URL used in addAuthHandler().
+	 */
+	void removeAuthHandler(const std::string &uri);
 
 	/**
 	 * getListeningPorts()
@@ -490,6 +543,17 @@ class CIVETWEB_API CivetServer
 	                                void *cbdata);
 	static void webSocketCloseHandler(const struct mg_connection *conn,
 	                                  void *cbdata);
+	/**
+	 * authHandler(struct mg_connection *, void *cbdata)
+	 *
+	 * Handles the authorization requests.
+	 *
+	 * @param conn - the connection information
+	 * @param cbdata - pointer to the CivetAuthHandler instance.
+	 * @returns 1 if authorized, 0 otherwise
+	 */
+	static int authHandler(struct mg_connection *conn, void *cbdata);
+
 	/**
 	 * closeHandler(struct mg_connection *)
 	 *

--- a/include/CivetServer.h
+++ b/include/CivetServer.h
@@ -113,7 +113,7 @@ class CIVETWEB_API CivetAuthHandler
 
 	/**
 	 * Callback method for authorization requests. It is up the this handler
-	 * to generate authorization requests.
+	 * to generate 401 responses if authorization fails.
 	 *
 	 * @param server - the calling server
 	 * @param conn - the connection information

--- a/include/CivetServer.h
+++ b/include/CivetServer.h
@@ -119,7 +119,7 @@ class CIVETWEB_API CivetAuthHandler
 	 * @param conn - the connection information
 	 * @returns true if authorization succeeded, false otherwise
 	 */
-	virtual bool authorize(CivetServer *server, struct mg_connection *conn);
+	virtual bool authorize(CivetServer *server, struct mg_connection *conn) = 0;
 };
 
 /**

--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -334,6 +334,15 @@ mg_set_websocket_handler(struct mg_context *ctx,
                          mg_websocket_close_handler close_handler,
                          void *cbdata);
 
+/* mg_set_auth_handler
+
+   Sets or removes a URI mapping for an authorization handler.
+   This function works similar to mg_set_request_handler - see there. */
+CIVETWEB_API void mg_set_auth_handler(struct mg_context *ctx,
+                                      const char *uri,
+                                      mg_request_handler handler,
+                                      void *cbdata);
+
 /* Get the value of particular configuration parameter.
    The value returned is read-only. Civetweb does not allow changing
    configuration at run time.

--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -334,13 +334,27 @@ mg_set_websocket_handler(struct mg_context *ctx,
                          mg_websocket_close_handler close_handler,
                          void *cbdata);
 
+/* mg_authorization_handler
+
+   Some description here
+
+   Parameters:
+      conn: current connection information.
+      cbdata: the callback data configured with mg_set_request_handler().
+   Returns:
+      0: access denied
+      1: access granted
+ */
+typedef int (*mg_authorization_handler)(struct mg_connection *conn,
+                                        void *cbdata);
+
 /* mg_set_auth_handler
 
    Sets or removes a URI mapping for an authorization handler.
    This function works similar to mg_set_request_handler - see there. */
 CIVETWEB_API void mg_set_auth_handler(struct mg_context *ctx,
                                       const char *uri,
-                                      mg_request_handler handler,
+                                      mg_authorization_handler handler,
                                       void *cbdata);
 
 /* Get the value of particular configuration parameter.

--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -105,6 +105,14 @@ CivetWebSocketHandler::handleClose(CivetServer *server,
 	return;
 }
 
+bool
+CivetAuthHandler::authorize(CivetServer *server, struct mg_connection *conn)
+{
+	UNUSED_PARAMETER(server);
+	UNUSED_PARAMETER(conn);
+	return false;
+}
+
 int
 CivetServer::requestHandler(struct mg_connection *conn, void *cbdata)
 {
@@ -137,6 +145,31 @@ CivetServer::requestHandler(struct mg_connection *conn, void *cbdata)
 		} else if (strcmp(request_info->request_method, "PATCH") == 0) {
 			return handler->handlePatch(me, conn) ? 1 : 0;
 		}
+	}
+
+	return 0; // No handler found
+}
+
+int
+CivetServer::authHandler(struct mg_connection *conn, void *cbdata)
+{
+	const struct mg_request_info *request_info = mg_get_request_info(conn);
+	assert(request_info != NULL);
+	CivetServer *me = (CivetServer *)(request_info->user_data);
+	assert(me != NULL);
+
+	// Happens when a request hits the server before the context is saved
+	if (me->context == NULL)
+		return 0;
+
+	mg_lock_context(me->context);
+	me->connections[conn] = CivetConnection();
+	mg_unlock_context(me->context);
+
+	CivetAuthHandler *handler = (CivetAuthHandler *)cbdata;
+
+	if (handler) {
+		return handler->authorize(me, conn) ? 1 : 0;
 	}
 
 	return 0; // No handler found
@@ -318,6 +351,12 @@ CivetServer::addWebSocketHandler(const std::string &uri,
 }
 
 void
+CivetServer::addAuthHandler(const std::string &uri, CivetAuthHandler *handler)
+{
+	mg_set_auth_handler(context, uri.c_str(), authHandler, handler);
+}
+
+void
 CivetServer::removeHandler(const std::string &uri)
 {
 	mg_set_request_handler(context, uri.c_str(), NULL, NULL);
@@ -328,6 +367,12 @@ CivetServer::removeWebSocketHandler(const std::string &uri)
 {
 	mg_set_websocket_handler(
 	    context, uri.c_str(), NULL, NULL, NULL, NULL, NULL);
+}
+
+void
+CivetServer::removeAuthHandler(const std::string &uri)
+{
+	mg_set_auth_handler(context, uri.c_str(), NULL, NULL);
 }
 
 void

--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -105,14 +105,6 @@ CivetWebSocketHandler::handleClose(CivetServer *server,
 	return;
 }
 
-bool
-CivetAuthHandler::authorize(CivetServer *server, struct mg_connection *conn)
-{
-	UNUSED_PARAMETER(server);
-	UNUSED_PARAMETER(conn);
-	return false;
-}
-
 int
 CivetServer::requestHandler(struct mg_connection *conn, void *cbdata)
 {
@@ -296,7 +288,7 @@ CivetServer::CivetServer(std::vector<std::string> options,
 	callbacks.connection_close = closeHandler;
 
 	std::vector<const char *> pointers(options.size());
-	for (int i = 0; i < options.size(); i++) {
+	for (size_t i = 0; i < options.size(); i++) {
 		pointers.push_back(options[i].c_str());
 	}
 	pointers.push_back(0);


### PR DESCRIPTION
We had a use case where we needed to use an in-memory user database and also needed to use Basic authentication. Instead trying to work this custom function into the guts of the handle_request() function, we came up with the idea to put a hook in to implement our special authorization handling code. This could open the door for other authorization backends (i.e. ldap, mysql) without too much disruption.

The function signature looks exactly like the request_handler, so I reused that and changed is_websocket_handler to handler_type, which is an enum as there is now 3 types of handlers (request, websocket, authorization).