### PR TITLE
Underflow when masking data smaller than 4 bytes

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -8606,7 +8606,7 @@ mask_data(const char *in, size_t in_len, uint32_t masking_key, char *out)
 	size_t i = 0;
 
 	i = 0;
-	if (((ptrdiff_t)in % 4) == 0) {
+	if ((in_len > 3) && ((ptrdiff_t)in % 4) == 0) {
 		/* Convert in 32 bit words, if data is 4 byte aligned */
 		while (i < (in_len - 3)) {
 			*(uint32_t *)(void *)(out + i) =

--- a/src/handle_form.inl
+++ b/src/handle_form.inl
@@ -281,7 +281,7 @@ mg_handle_form_data(struct mg_connection *conn,
 			ptrdiff_t keylen, vallen;
 			ptrdiff_t used;
 			FILE *fstore = NULL;
-			int end_of_data_found;
+			int end_of_data_found = 0;
 
 			if ((size_t)buf_fill < (sizeof(buf) - 1)) {
 


### PR DESCRIPTION
If in_len is initially less than 4 bytes, the "in_len - 3" will underflow causing incorrect behavior.