### PR TITLE
Correcting minor typo

### DIFF
--- a/docs/Embedding.md
+++ b/docs/Embedding.md
@@ -21,7 +21,7 @@ These files constitute the CivetWeb library.  They do not contain a `main` funct
 but all functions required to run a HTTP server.
 
   - HTTP Server API
-      - include/civetweb.c
+      - include/civetweb.h
   - C implementation
     - src/civetweb.c
     - src/md5.inl (MD5 calculation)    


### PR DESCRIPTION
There is a minor typo in /docs/Embedding.md. Line 28:

  - include/civetweb.c

Should be:

  - include/civetweb.h