### PR TITLE
Only free conn if in client context.

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -10971,9 +10971,9 @@ mg_close_connection(struct mg_connection *conn)
 		}
 		mg_free(client_ctx->workerthreadids);
 		mg_free(client_ctx);
+		mg_free(conn);
 	}
 	(void)pthread_mutex_destroy(&conn->mutex);
-	mg_free(conn);
 }
 
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -10971,9 +10971,9 @@ mg_close_connection(struct mg_connection *conn)
 		}
 		mg_free(client_ctx->workerthreadids);
 		mg_free(client_ctx);
+		(void)pthread_mutex_destroy(&conn->mutex);
 		mg_free(conn);
 	}
-	(void)pthread_mutex_destroy(&conn->mutex);
 }
 
 


### PR DESCRIPTION
The worker_thread_run function will free the conn memory when it quits.
Freeing it in mg_close_connection frees it too early, causing a crash in
the worker_thread_run function as it reuses conn until the server quits
and asks the thread to quit.