### PR TITLE
In read_request() function, last_action_time is always zero before en…

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -6736,6 +6736,10 @@ read_request(FILE *fp,
 	}
 
 	request_len = get_request_len(buf, *nread);
+
+    /* first time reading from this connection */
+    clock_gettime(CLOCK_MONOTONIC, &last_action_time);
+
 	while (
 	    (conn->ctx->stop_flag == 0) && (*nread < bufsiz) && (request_len == 0)
 	    && ((mg_difftimespec(&last_action_time, &(conn->req_time))


### PR DESCRIPTION
…tering the while loop

One of the he while loop conditions is

((mg_difftimespec(&last_action_time, &(conn->req_time)) <=
	      request_timeout) ||
	     (request_timeout < 0)) 

Since request_timeout is set at a default of 30 seconds, it is not less than 0.
First time entering the loop, last_action_time is zero. Hence mg_difftimespec() returns a very large number (rolled over from 0 minus positive number from conn->req_time) and the while loop never gets entered. 

 