### PR TITLE
Add mg_send_mime_file.

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -588,6 +588,16 @@ CIVETWEB_API int mg_printf(struct mg_connection *,
 /* Send contents of the entire file together with HTTP headers. */
 CIVETWEB_API void mg_send_file(struct mg_connection *conn, const char *path);
 
+/* Send contents of the entire file together with HTTP headers.
+   Parameters:
+     conn: Current connection information.
+     path: Full path to the file to send.
+     mime_type: Content-Type for file.  NULL will cause the type to be
+                looked up by the file extension.
+*/
+CIVETWEB_API void mg_send_mime_file(struct mg_connection *conn,
+				    const char *path,
+				    const char *mime_type);
 
 /* Store body data into a file. */
 CIVETWEB_API long long mg_store_body(struct mg_connection *conn,

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -6330,7 +6330,8 @@ fclose_on_exec(struct file *filep, struct mg_connection *conn)
 static void
 handle_static_file_request(struct mg_connection *conn,
                            const char *path,
-                           struct file *filep)
+                           struct file *filep,
+                           const char *mime_type)
 {
 	char date[64], lm[64], etag[64];
 	char range[128]; /* large enough, so there will be no overflow */
@@ -6347,7 +6348,12 @@ handle_static_file_request(struct mg_connection *conn,
 		return;
 	}
 
-	get_mime_type(conn->ctx, path, &mime_vec);
+	if (mime_type == NULL) {
+		get_mime_type(conn->ctx, path, &mime_vec);
+	} else {
+		mime_vec.ptr = mime_type;
+		mime_vec.len = strlen(mime_type);
+	}
 	if (filep->size > INT64_MAX) {
 		send_http_error(conn,
 		                500,
@@ -6474,6 +6480,15 @@ handle_static_file_request(struct mg_connection *conn,
 void
 mg_send_file(struct mg_connection *conn, const char *path)
 {
+	mg_send_mime_file(conn, path, NULL);
+  
+}
+
+void
+mg_send_mime_file(struct mg_connection *conn,
+		  const char *path,
+		  const char *mime_type)
+{
 	struct file file = STRUCT_FILE_INITIALIZER;
 	if (mg_stat(conn, path, &file)) {
 		if (file.is_directory) {
@@ -6490,7 +6505,7 @@ mg_send_file(struct mg_connection *conn, const char *path)
 				                "Error: Directory listing denied");
 			}
 		} else {
-			handle_static_file_request(conn, path, &file);
+			handle_static_file_request(conn, path, &file, mime_type);
 		}
 	} else {
 		send_http_error(conn, 404, "%s", "Error: File not found");
@@ -9981,7 +9996,7 @@ handle_file_based_request(struct mg_connection *conn,
 		/* Send 304 "Not Modified" - this must not send any body data */
 		send_http_error(conn, 304, "%s", "");
 	} else {
-		handle_static_file_request(conn, path, file);
+		handle_static_file_request(conn, path, file, NULL);
 	}
 }
 


### PR DESCRIPTION
This allows sending files with a specified Content-Type instead of
relying on file name extension lookup.

Addresses #271 