### PR TITLE
Added certificate hot swap for use with short lived certificates

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -10568,10 +10568,10 @@ sslize(struct mg_connection *conn, SSL_CTX *s, int (*func)(SSL *))
 		char *pem;
 		if ((pem = conn->ctx->config[SSL_CERTIFICATE]) == NULL
 			&& conn->ctx->callbacks.init_ssl == NULL) {
-			return 1;
+			return 0;
 		}
 		if (ssl_use_pem_file(conn->ctx, pem) == 0) {
-			return 1;
+			return 0;
 		}
 	}
 	conn->ssl = SSL_new(s);


### PR DESCRIPTION
This reloads the certificate and ca certificate on every request. The goal is to provide functionality for short lived certificates. The functionality can be enabled with the config option "ssl_short_trust".

It's advised to keep the certificates stored on tmpfs on systems with high throughput because of the increased disk io.

Why Short-Lived Trust?
Certificate Revocation Lists (CRLs) and Online Certificate Status Protocol (OCSP) are great technologies for checking the current status of certificates. The problem with these technologies is, that they introduce both scale and management challenges in deployed cloud applications. Short-lived trust enables added security in such environments, since compromised keys are less valuable to an attacker.