### PR TITLE
Fix the checking of 'keep-alive' connection flag.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,10 @@ local.properties
 *.user
 *.sln.docstates
 
+# Text-mode IDE tools
+cscope.out
+tags
+
 # Build results
 
 [Dd]ebug/

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -2052,10 +2052,17 @@ mg_get_header(const struct mg_connection *conn, const char *name)
 static const char *
 next_option(const char *list, struct vec *val, struct vec *eq_val)
 {
+	int end;
+
+reparse:
 	if (val == NULL || list == NULL || *list == '\0') {
 		/* End of the list */
 		list = NULL;
 	} else {
+		/* Skip over leading LWS */
+		while (*list == ' ' || *list == '\t')
+			list++;
+
 		val->ptr = list;
 		if ((list = strchr(val->ptr, ',')) != NULL) {
 			/* Comma found. Store length and shift the list ptr */
@@ -2065,6 +2072,17 @@ next_option(const char *list, struct vec *val, struct vec *eq_val)
 			/* This value is the last one */
 			list = val->ptr + strlen(val->ptr);
 			val->len = ((size_t)(list - val->ptr));
+		}
+
+		/* Adjust length for trailing LWS */
+		end = val->len - 1;
+		while (end >= 0 && (val->ptr[end] == ' ' || val->ptr[end] == '\t'))
+			end--;
+		val->len = end + 1;
+
+		if (val->len == 0) {
+			/* Ignore any empty entries. */
+			goto reparse;
 		}
 
 		if (eq_val != NULL) {
@@ -2083,6 +2101,24 @@ next_option(const char *list, struct vec *val, struct vec *eq_val)
 	return list;
 }
 
+/* A helper function for checking if a comma separated list of values contains
+ * the given option (case insensitvely).
+ * 'header' can be NULL, in which case false is returned. */
+static int header_has_option(const char *header, const char *option)
+{
+	struct vec opt_vec;
+	struct vec eq_vec;
+
+	assert(option != NULL);
+	assert(option[0] != '\0');
+
+	while ((header = next_option(header, &opt_vec, &eq_vec)) != NULL) {
+		if (mg_strncasecmp(option, opt_vec.ptr, opt_vec.len) == 0)
+			return 1;
+	}
+
+	return 0;
+}
 
 /* Perform case-insensitive match of string against pattern */
 static int
@@ -2139,7 +2175,7 @@ should_keep_alive(const struct mg_connection *conn)
 		const char *header = mg_get_header(conn, "Connection");
 		if (conn->must_close || conn->internal_error || conn->status_code == 401
 		    || mg_strcasecmp(conn->ctx->config[ENABLE_KEEP_ALIVE], "yes") != 0
-		    || (header != NULL && mg_strcasecmp(header, "keep-alive") != 0)
+		    || (header != NULL && !header_has_option(header, "keep-alive"))
 		    || (header == NULL && http_version
 		        && 0 != strcmp(http_version, "1.1"))) {
 			return 0;
@@ -7472,8 +7508,7 @@ handle_cgi_request(struct mg_connection *conn, const char *prog)
 		conn->status_code = 200;
 	}
 	connection_state = get_header(&ri, "Connection");
-	if (connection_state == NULL
-	    || mg_strcasecmp(connection_state, "keep-alive")) {
+	if (!header_has_option(connection_state, "keep-alive")) {
 		conn->must_close = 1;
 	}
 	(void)mg_printf(conn, "HTTP/1.1 %d %s\r\n", conn->status_code, status_text);

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -3858,11 +3858,17 @@ pull(FILE *fp, struct mg_connection *conn, char *buf, int len, double timeout)
 			 * blocking in close_socket_gracefully, so we can not distinguish
 			 * here. We have to wait for the timeout in both cases for now.
 			 */
-			if (err == EAGAIN || err == EWOULDBLOCK) {
-				/* standard case if called from close_socket_gracefully
+			if (err == EAGAIN || err == EWOULDBLOCK || err == EINTR) {
+				/* EAGAIN/EWOULDBLOCK:
+				 * standard case if called from close_socket_gracefully
 				 * => should return -1 */
 				/* or timeout occured
 				 * => the code must stay in the while loop */
+
+				/* EINTR can be generated on a socket with a timeout set even
+				 * when SA_RESTART is effective for all relevant signals
+				 * (see signal(7)).
+				 * => stay in the while loop */
 			} else {
 				DEBUG_TRACE("recv() failed, error %d", err);
 				return -1;

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -2075,10 +2075,10 @@ reparse:
 		}
 
 		/* Adjust length for trailing LWS */
-		end = val->len - 1;
+		end = (int)val->len - 1;
 		while (end >= 0 && (val->ptr[end] == ' ' || val->ptr[end] == '\t'))
 			end--;
-		val->len = end + 1;
+		val->len = (size_t)(end + 1);
 
 		if (val->len == 0) {
 			/* Ignore any empty entries. */


### PR DESCRIPTION
Hi,

The "Connection:" header can contain multiple entries. In my specific case, I'm handling a WebSocket connection with keep-alive (so, the header is "Connection: keep-alive, Upgrade" - at least when the websocket is opened from Firefox).

The current places that check for "keep-alive" in the "Connection" header do a string compare against the whole header.

So, this patch:

1) Adds a utility function for checking if a specific option is listed in a multi-option (comma-separated) header.
2) Modifies the next_option() function to strip leading and trailing whitespace from the option. As mentioned above, the Firefox-generated header has a space after the comma, and a brief glance at the RFC seems to say that's allowable anywhere between tokens. I have not analysed the code to see if other uses of next_option() should /not/ have that behaviour.
3) Modifies the two existing places where 'keep-alive' was being tested, to use the new function.

Notes on the implementation:

I use assert() - I presume that is OK?

It uses 'goto' to skip any blank entries it finds (i.e., "Connection: keep-alive,,Upgrade,"). I notice that the source does not generally use 'goto' unless for tidy-up purposes. I don't think the use of goto in this patch is particularly bad, but if you don't like it I could submit a different patch. Suggestions for approaches would be:

1) Create a two-stage function (the outer function just loops as long as the inner function is returning empty entries).
2) Use an outer "for(;;)" loop such that 'continue' will do the same as the 'goto' and there's a trailing 'break' should it get to the bottom (i.e., it's not actually a loop, just a construct with two unnamed branch targets ...).
3) Recursion. [FWIW, I don't like this one as it's operating on externally-generated data and a huge header containing many commas would cause it to recurse deeply. A good optimizer /should/ optimize out the tail recursion, but why leave that to chance?]

I've attached a stand-alone test program (it doesn't need to actually start a server).

K.

[option_test.zip](https://github.com/civetweb/civetweb/files/186405/option_test.zip)
