### PR TITLE
Improved certificate hot swap for use with short lived certificates

### DIFF
--- a/docs/UserManual.md
+++ b/docs/UserManual.md
@@ -439,6 +439,18 @@ TLS1.0+TLS1.1+TLS1.2 | 2
 TLS1.1+TLS1.2 | 3
 TLS1.2 | 4
 
+### ssl_short_trust `no`
+Enables the use of short lived certificates. This will allow for the certificates
+and keys specified in `ssl_certificate`, `ssl_ca_file` and `ssl_ca_path` to be 
+exchanged and reloaded while the server is running.
+
+In an automated environment it is advised to first write the new pem file to
+a different filename and then to rename it to the configured pem file name to
+increase performance while swapping the certificate.
+
+Disk IO performance can be improved when keeping the certificates and keys stored
+on a tmpfs (linux) on a system with very high throughput.
+
 # Lua Scripts and Lua Server Pages
 Pre-built Windows and Mac civetweb binaries have built-in Lua scripting
 support as well as support for Lua Server Pages.

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -10543,37 +10543,59 @@ sslize(struct mg_connection *conn, SSL_CTX *s, int (*func)(SSL *))
 		return 0;
 	}
 
-	int short_trust = !strcmp(conn->ctx->config[SSL_SHORT_TRUST], "yes");
-	if (short_trust) {
-		int should_verify_peer =
-				(conn->ctx->config[SSL_DO_VERIFY_PEER] != NULL)
-				&& (mg_strcasecmp(conn->ctx->config[SSL_DO_VERIFY_PEER], "yes") == 0);
+	static int reload_lock = 0;
+	static long int data_check = 0;
 
-		if (should_verify_peer) {
-			char *ca_path = conn->ctx->config[SSL_CA_PATH];
-			char *ca_file = conn->ctx->config[SSL_CA_FILE];
-			if (SSL_CTX_load_verify_locations(conn->ctx->ssl_ctx, ca_file, ca_path)
-				!= 1) {
-				mg_cry(fc(conn->ctx),
-					   "SSL_CTX_load_verify_locations error: %s "
-							   "ssl_verify_peer requires setting "
-							   "either ssl_ca_path or ssl_ca_file. Is any of them "
-							   "present in "
-							   "the .conf file?",
-					   ssl_error());
-				return 0;
+	char *pem;
+	if ((pem = conn->ctx->config[SSL_CERTIFICATE]) == NULL
+		&& conn->ctx->callbacks.init_ssl == NULL) {
+		return 0;
+	}
+
+	struct stat cert_buf;
+	long int t = data_check;
+	if (stat(pem, &cert_buf) != -1) {
+		t = (long int) cert_buf.st_mtime;
+	}
+
+	int short_trust = !strcmp(conn->ctx->config[SSL_SHORT_TRUST], "yes");
+	if (data_check != t) {
+		data_check = t;
+		if (short_trust) {
+			int should_verify_peer =
+					(conn->ctx->config[SSL_DO_VERIFY_PEER] != NULL)
+					&& (mg_strcasecmp(conn->ctx->config[SSL_DO_VERIFY_PEER], "yes") == 0);
+
+			if (should_verify_peer) {
+				char *ca_path = conn->ctx->config[SSL_CA_PATH];
+				char *ca_file = conn->ctx->config[SSL_CA_FILE];
+				if (SSL_CTX_load_verify_locations(conn->ctx->ssl_ctx, ca_file, ca_path)
+					!= 1) {
+					mg_cry(fc(conn->ctx),
+						   "SSL_CTX_load_verify_locations error: %s "
+								   "ssl_verify_peer requires setting "
+								   "either ssl_ca_path or ssl_ca_file. Is any of them "
+								   "present in "
+								   "the .conf file?",
+						   ssl_error());
+					return 0;
+				}
+			}
+
+			if (!reload_lock) {
+				reload_lock = 1;
+				if (ssl_use_pem_file(conn->ctx, pem) == 0) {
+					return 0;
+				}
+				reload_lock = 0;
 			}
 		}
-
-		char *pem;
-		if ((pem = conn->ctx->config[SSL_CERTIFICATE]) == NULL
-			&& conn->ctx->callbacks.init_ssl == NULL) {
-			return 0;
-		}
-		if (ssl_use_pem_file(conn->ctx, pem) == 0) {
-			return 0;
-		}
 	}
+	/* lock while cert is reloading */
+	while (reload_lock) {
+		sleep(1);
+	}
+
 	conn->ssl = SSL_new(s);
 	if (conn->ssl == NULL) {
 		return 0;


### PR DESCRIPTION
A follow up for pull request #280 _(Added certificate hot swap for use with short lived certificates)_

The following improvements have been made:
* This version stats the cert / key pem file and checks if a new version is available and only reloads then.
* Fixed a threading issue while reloading the certificate.
* Added documentation for the `ssl_short_trust` option.