### PR TITLE
Exclude GCC from OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2386,7 +2386,7 @@ cache:
   - $HOME/third-party
 
 matrix:
-  - fast_finish: true
+  fast_finish: true
   exclude:
     # Exclude GCC from OS X builds because it's actually clang so it's just duplicate builds
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -2387,6 +2387,10 @@ cache:
 
 matrix:
   - fast_finish: true
+  exclude:
+    # Exclude GCC from OS X builds because it's actually clang so it's just duplicate builds
+    - os: osx
+      compiler: gcc
 
 script:
   - CTEST_OUTPUT_ON_FAILURE=1 make all test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2327,10 +2327,6 @@ env:
 #      ENABLE_LUA=YES
 #      ENABLE_DUKTAPE=YES
 
-matrix:
-  allow_failures:
-    - os: osx
-
 addons:
   apt:
     packages:


### PR DESCRIPTION
A few small Travis changes.

I added the exclude to the first matrix, but it didn't work until I added it to the second, so I think the second matrix key was overwriting the first.