### PR TITLE
Fix "argument unused during compilation"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,9 @@ if (HAVE_C_FLAG_FSANITIZE_ADDRESS)
   add_c_compiler_flag(-static-asan DEBUG)
 endif()
 add_c_compiler_flag(-fstack-protector-all DEBUG)
-add_c_compiler_flag(-mwindows)
+if (MINGW)
+  add_c_compiler_flag(-mwindows)
+endif()
 
 # Coverage build type
 set(CMAKE_C_FLAGS_COVERAGE "${CMAKE_C_FLAGS_DEBUG}" CACHE STRING
@@ -343,7 +345,9 @@ if (CIVETWEB_ENABLE_CXX)
     add_cxx_compiler_flag(-static-asan DEBUG)
   endif()
   add_cxx_compiler_flag(-fstack-protector-all DEBUG)
-  add_cxx_compiler_flag(-mwindows)
+  if (MINGW)
+    add_cxx_compiler_flag(-mwindows)
+  endif()
   set(CMAKE_CXX_FLAGS_COVERAGE "${CMAKE_CXX_FLAGS_DEBUG}" CACHE STRING
       "Flags used by the C++ compiler during coverage builds."
       FORCE)


### PR DESCRIPTION
Apparently -mwindows flag doesn't produce an error for the way the current CMake code checks, so the flag gets added on OS X (Clang) but then this produces a warning during compilation.