### PR TITLE
Adding a callback that is called when a new worker thread is initialized

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -206,6 +206,11 @@ struct mg_callbacks {
 	     ctx: context handle */
 	void (*init_context)(const struct mg_context *ctx);
 
+	/* Called when a new worker thread is initialized.
+	   Parameters:
+	     ctx: context handle */
+	void(*init_thread)(const struct mg_context *ctx);
+
 	/* Called when civetweb context is deleted.
 	   Parameters:
 	     ctx: context handle */

--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -208,8 +208,9 @@ struct mg_callbacks {
 
 	/* Called when a new worker thread is initialized.
 	   Parameters:
-	     ctx: context handle */
-	void(*init_thread)(const struct mg_context *ctx);
+	     ctx: context handle
+	     thread_type: a value of 1 indicates a worker thread. */
+	void(*init_thread)(const struct mg_context *ctx, int thread_type);
 
 	/* Called when civetweb context is deleted.
 	   Parameters:

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -12291,6 +12291,10 @@ worker_thread_run(void *thread_func_param)
 	uint32_t addr;
 #endif
 
+	if (ctx->callbacks.init_thread) {
+		ctx->callbacks.init_thread(ctx);
+	}
+
 	mg_set_thread_name("worker");
 
 	tls.is_master = 0;

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -12291,10 +12291,6 @@ worker_thread_run(void *thread_func_param)
 	uint32_t addr;
 #endif
 
-	if (ctx->callbacks.init_thread) {
-		ctx->callbacks.init_thread(ctx);
-	}
-
 	mg_set_thread_name("worker");
 
 	tls.is_master = 0;
@@ -12302,6 +12298,10 @@ worker_thread_run(void *thread_func_param)
 #if defined(_WIN32) && !defined(__SYMBIAN32__)
 	tls.pthread_cond_helper_mutex = CreateEvent(NULL, FALSE, FALSE, NULL);
 #endif
+
+	if (ctx->callbacks.init_thread) {
+		ctx->callbacks.init_thread(ctx, 1);
+	}
 
 	conn =
 	    (struct mg_connection *)mg_calloc(1, sizeof(*conn) + MAX_REQUEST_SIZE);


### PR DESCRIPTION
My application embeds a Python interpreter. Python requires each thread to be initialized specifically for use with Python (see https://docs.python.org/3.5/c-api/init.html)
This pull request adds a new callback function that is called when a new worker thread is initialized.  

See [this dicussion on the google group](https://groups.google.com/forum/#!topic/civetweb/W-PqjC1pjes).