### PR TITLE
Automatically initialize mg_callbacks to NULL in constructor

### DIFF
--- a/include/CivetServer.h
+++ b/include/CivetServer.h
@@ -193,6 +193,15 @@ class CIVETWEB_API CivetWebSocketHandler
 };
 
 /**
+ * CivetCallbacks
+ *
+ * wrapper for mg_callbacks
+ */
+struct CIVETWEB_API CivetCallbacks : public mg_callbacks {
+    CivetCallbacks();
+};
+
+/**
  * CivetServer
  *
  * Basic class for embedded web server.  This has an URL mapping built-in.
@@ -217,9 +226,9 @@ class CIVETWEB_API CivetServer
 	 *
 	 * @throws CivetException
 	 */
-	CivetServer(const char **options, const struct mg_callbacks *callbacks = 0);
+	CivetServer(const char **options, const struct CivetCallbacks *callbacks = 0);
 	CivetServer(std::vector<std::string> options,
-	            const struct mg_callbacks *callbacks = 0);
+	            const struct CivetCallbacks *callbacks = 0);
 
 	/**
 	 * Destructor

--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -263,12 +263,16 @@ CivetServer::webSocketCloseHandler(const struct mg_connection *conn,
 	}
 }
 
+CivetCallbacks::CivetCallbacks()
+{
+    memset(this, 0, sizeof(*this));
+}
+
 CivetServer::CivetServer(const char **options,
-                         const struct mg_callbacks *_callbacks)
+                         const struct CivetCallbacks *_callbacks)
     : context(0)
 {
-	struct mg_callbacks callbacks;
-	memset(&callbacks, 0, sizeof(callbacks));
+	struct CivetCallbacks callbacks;
 
 	if (_callbacks) {
 		callbacks = *_callbacks;
@@ -284,11 +288,10 @@ CivetServer::CivetServer(const char **options,
 }
 
 CivetServer::CivetServer(std::vector<std::string> options,
-                         const struct mg_callbacks *_callbacks)
+                         const struct CivetCallbacks *_callbacks)
     : context(0)
 {
-	struct mg_callbacks callbacks;
-	memset(&callbacks, 0, sizeof(callbacks));
+	struct CivetCallbacks callbacks;
 
 	if (_callbacks) {
 		callbacks = *_callbacks;


### PR DESCRIPTION
Forgetting the memset when using the C++ constructor yields invalid pointers