### PR TITLE
Fix "Macro name is a reserved identifier" on OS X

### DIFF
--- a/test/shared.c
+++ b/test/shared.c
@@ -19,11 +19,13 @@
  * THE SOFTWARE.
  */
 
+#ifdef _MSC_VER
 #if !defined(_CRT_SECURE_NO_WARNINGS)
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 #if !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE
+#endif
 #endif
 
 #include "shared.h"


### PR DESCRIPTION
This also more accurately only sets these definitions for MSVC.