### PR TITLE
Add Lua to OS X app

### DIFF
--- a/Makefile.osx
+++ b/Makefile.osx
@@ -7,6 +7,9 @@
 # security unlock ~/Library/Keychains/login.keychain
 # See e.g. http://lists.apple.com/archives/apple-cdsa/2008/Jan/msg00027.html
 
+# Civetweb features
+WITH_LUA = 1
+
 PACKAGE = Civetweb
 BUILD_DIR = out
 


### PR DESCRIPTION
I tested this by using the sample .lp script in the manual.

I also set resources/ssl_cert.pem as the `ssl_certificate` and confirmed SSL is working. So I imagine that's dynamically loading the OpenSSL library that is built-in to OS X, which is pretty old. Apple deprecated it a while ago and dropped the headers from the most recent SDK. Ideally, the OS X app should use the latest OpenSSL build and static compile it into the binary. I did get this working as a test, but it'd be more work to set it up for automation, as OpenSSL would need to be downloaded, and `makedepend` needs to be downloaded compiled as an OpenSSL build dependency as well. Then OpenSSL's Makefile needs to be modified to set the OS X minimum version to match what civetweb uses. If I ever get that functioning, we should increase the OS X minimum version so we don't need to build both for 32-bit and 64-bit (10.7 is 64-bit only).