### PR TITLE
Alternate API for mg_upload replacement

### DIFF
--- a/examples/embedded_c/embedded_c.c
+++ b/examples/embedded_c/embedded_c.c
@@ -298,7 +298,7 @@ CookieHandler(struct mg_connection *conn, void *cbdata)
 	mg_printf(conn, "Content-Type: text/html\r\n\r\n");
 
 	mg_printf(conn, "<html><body>");
-	mg_printf(conn, "<h2>This is the CookieHandler.</h2>", cbdata);
+	mg_printf(conn, "<h2>This is the CookieHandler.</h2>");
 	mg_printf(conn, "<p>The actual uri is %s</p>", req_info->uri);
 
 	if (first_str[0] == 0) {

--- a/examples/embedded_c/embedded_c.c
+++ b/examples/embedded_c/embedded_c.c
@@ -194,13 +194,14 @@ FileHandler(struct mg_connection *conn, void *cbdata)
 
 
 int
-field_found(const char *key,
-            const char *filename,
-            char *path,
-            size_t pathlen,
+field_found(struct mg_form_data *field,
             void *user_data)
 {
-	struct mg_connection *conn = (struct mg_connection *)user_data;
+	struct mg_connection *conn = mg_get_form_connection(field);
+	const char *key = mg_get_form_key(field);
+	const char *filename = mg_get_form_filename(field);
+	char path[512];
+	int ret;
 
 	mg_printf(conn, "\r\n\r\n%s:\r\n", key);
 
@@ -208,37 +209,28 @@ field_found(const char *key,
 #ifdef _WIN32
 		_snprintf(path, pathlen, "D:\\tmp\\%s", filename);
 #else
-		snprintf(path, pathlen, "/tmp/%s", filename);
+		snprintf(path, sizeof(path), "/tmp/%s", filename);
 #endif
-		return FORM_FIELD_STORAGE_STORE;
+		ret = mg_store_form_data(field, path);
+		if (ret < 0) {
+			return -1;
+		}
+		mg_printf(conn,
+		          "stored as %s (%lu bytes)\r\n\r\n",
+		          path,
+		          (unsigned long)ret);
+		return 0;
 	}
-	return FORM_FIELD_STORAGE_GET;
-}
 
-
-int
-field_get(const char *key, const char *value, size_t valuelen, void *user_data)
-{
-	struct mg_connection *conn = (struct mg_connection *)user_data;
-
-	if (key[0]) {
-		mg_printf(conn, "%s = ", key);
+	ret = mg_read_form_data(field, path, sizeof(path) - 1);
+	if (ret < 0) {
+		return -1;
 	}
-	mg_write(conn, value, valuelen);
 
-	return 0;
-}
+	path[ret] = '\0';
 
-
-int
-field_stored(const char *path, long long file_size, void *user_data)
-{
-	struct mg_connection *conn = (struct mg_connection *)user_data;
-
-	mg_printf(conn,
-	          "stored as %s (%lu bytes)\r\n\r\n",
-	          path,
-	          (unsigned long)file_size);
+	mg_printf(conn, "%s = ", key);
+	mg_write(conn, path, ret);
 
 	return 0;
 }
@@ -250,18 +242,16 @@ FormHandler(struct mg_connection *conn, void *cbdata)
 	/* Handler may access the request info using mg_get_request_info */
 	const struct mg_request_info *req_info = mg_get_request_info(conn);
 	int ret;
-	struct mg_form_data_handler fdh = {field_found, field_get, field_stored, 0};
 
 	/* It would be possible to check the request info here before calling
 	 * mg_handle_form_request. */
 	(void)req_info;
 
 	mg_printf(conn, "HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\n\r\n");
-	fdh.user_data = (void *)conn;
 
 	/* Call the form handler */
 	mg_printf(conn, "Form data:");
-	ret = mg_handle_form_request(conn, &fdh);
+	ret = mg_handle_form_data(conn, &field_found, NULL);
 	mg_printf(conn, "\r\n%i fields found", ret);
 
 	return 1;

--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -754,6 +754,54 @@ CIVETWEB_API int mg_upload(struct mg_connection *conn,
 #endif
 
 
+struct mg_form_data;
+
+/* This callback function is called if a new field has been found.
+ * The callback should examine the key and read the field's data using
+ * mg_form_data_read(). Data not read will be discarded.
+ *
+ * Parameters:
+ *   field: Form field handle.
+ *   user_data: Value of the user_data parameter to mg_handle_form_data().
+ *
+ * Return value:
+ *   0 after successful field handling, < 0 to abort form processing.
+ */
+typedef int (*mg_form_data_callback)(struct mg_form_data *field,
+                                    void *user_data);
+
+/* Process form data.
+ * Returns the number of fields handled, or < 0 in case of an error.
+ * Note: It is possible that several fields are already handled successfully
+ * (e.g., stored into files), before the request handling is stopped with an
+ * error. In this case a number < 0 is returned as well.
+ * In any case, it is the duty of the caller to perform any necessary
+ * cleanup. */
+CIVETWEB_API int mg_handle_form_data(struct mg_connection *conn,
+                                     mg_form_data_callback fdh,
+                                     void *user_data);
+
+/* Get the form field's key ("name" property of the HTML input field). */
+CIVETWEB_API const char *mg_get_form_key(struct mg_form_data *fd);
+
+/* Get the client-provided file name for the form field (for input fields
+ * of type "file"), or NULL if none was provided. */
+CIVETWEB_API const char *mg_get_form_filename(struct mg_form_data *fd);
+
+/* Get the connection associated with form data handle fd. */
+CIVETWEB_API struct mg_connection *mg_get_form_connection(struct mg_form_data *fd);
+
+/* Read form data associated with form data handle fd. This has the same
+ * semantics as mg_read(). */
+CIVETWEB_API int mg_read_form_data(struct mg_form_data *fd,
+                                   void *buf,
+                                   size_t len);
+
+/* Convenience function for storing form data to file from a mg_form_data_callback.
+ * filename may be NULL to use the client provided name, if any. */
+CIVETWEB_API int mg_store_form_data(struct mg_form_data *fd,
+                                    const char *filename);
+
 /* This structure contains callback functions for handling form fields.
    It is used as an argument to mg_handle_form_request. */
 struct mg_form_data_handler {

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -9258,15 +9258,14 @@ get_remote_ip(const struct mg_connection *conn)
 }
 
 
-/* The mg_upload function is superseeded by mg_handle_form_request. */
+/* The mg_upload function is superseeded by mg_handle_form_data. */
 #include "handle_form.inl"
-
 
 #if defined(MG_LEGACY_INTERFACE)
 /* Implement the deprecated mg_upload function by calling the new
- * mg_handle_form_request function. While mg_upload could only handle
+ * mg_handle_form_data function. While mg_upload could only handle
  * HTML forms sent as POST request in multipart/form-data format
- * containing only file input elements, mg_handle_form_request can
+ * containing only file input elements, mg_handle_form_data can
  * handle all form input elements and all standard request methods. */
 struct mg_upload_user_data {
 	struct mg_connection *conn;
@@ -9277,58 +9276,36 @@ struct mg_upload_user_data {
 
 /* Helper function for deprecated mg_upload. */
 static int
-mg_upload_field_found(const char *key,
-                      const char *filename,
-                      char *path,
-                      size_t pathlen,
+mg_upload_field_found(struct mg_form_data *field,
                       void *user_data)
 {
+	const char *filename;
 	int truncated = 0;
 	struct mg_upload_user_data *fud = (struct mg_upload_user_data *)user_data;
-	(void)key;
+	char path[512];
+	int ret;
 
+	filename = mg_get_form_filename(field);
 	if (!filename) {
 		mg_cry(fud->conn, "%s: No filename set", __func__);
-		return FORM_FIELD_STORAGE_ABORT;
+		return -1;
 	}
 	mg_snprintf(fud->conn,
 	            &truncated,
 	            path,
-	            pathlen - 1,
+	            sizeof(path) - 1,
 	            "%s/%s",
 	            fud->destination_dir,
 	            filename);
 	if (!truncated) {
 		mg_cry(fud->conn, "%s: File path too long", __func__);
-		return FORM_FIELD_STORAGE_ABORT;
+		return -1;
 	}
-	return FORM_FIELD_STORAGE_STORE;
-}
 
-
-/* Helper function for deprecated mg_upload. */
-static int
-mg_upload_field_get(const char *key,
-                    const char *value,
-                    size_t value_size,
-                    void *user_data)
-{
-	/* Function should never be called */
-	(void)key;
-	(void)value;
-	(void)value_size;
-	(void)user_data;
-
-	return 0;
-}
-
-
-/* Helper function for deprecated mg_upload. */
-static int
-mg_upload_field_stored(const char *path, long long file_size, void *user_data)
-{
-	struct mg_upload_user_data *fud = (struct mg_upload_user_data *)user_data;
-	(void)file_size;
+	ret = mg_store_form_data(field, filename);
+	if (ret < 0) {
+		return -1;
+	}
 
 	fud->num_uploaded_files++;
 	fud->conn->ctx->callbacks.upload(fud->conn, path);
@@ -9342,14 +9319,9 @@ int
 mg_upload(struct mg_connection *conn, const char *destination_dir)
 {
 	struct mg_upload_user_data fud = {conn, destination_dir, 0};
-	struct mg_form_data_handler fdh = {mg_upload_field_found,
-	                                   mg_upload_field_get,
-	                                   mg_upload_field_stored,
-	                                   0};
 	int ret;
 
-	fdh.user_data = (void *)&fud;
-	ret = mg_handle_form_request(conn, &fdh);
+	ret = mg_handle_form_data(conn, mg_upload_field_found, (void *)&fud);
 
 	if (ret < 0) {
 		mg_cry(conn, "%s: Error while parsing the request", __func__);


### PR DESCRIPTION
I realize it's a bit late to give feedback on the recently released mg_handle_form_request improvement over mg_upload. Still, I have a bit of an issue with the API.

Some background: I needed to parse a big file on the fly (unpack an archive to be precise) on an embedded system and found that it wasn't supported using the existing form data parser (mg_upload). I started thinking on how to implement an improvement before I saw the work in progress replacement upstream. Unfortunately it appears that the replacement does not support that use-case either (yet) and I found it very hard to extend to support it. So I wrote a separate form handler, using an API more suited for my use-case (and I think it works well for other cases too).

This is not yet complete, as it says it the commit comment, since I only implemented the multipart/form-data I needed to move forward. Nevertheless, the API should be unchanged and it should be straight-forward to implement the other method/encoding. If you like the idea I can do it, if not I'll just use it as it is until mg_handle_form_request supports streaming data.
