### PR TITLE
Fix unexpected 301 response

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -10099,7 +10099,9 @@ handle_request(struct mg_connection *conn)
 		}
 
 		/* 12. Directory uris should end with a slash */
-		if (file.is_directory && ri->local_uri[uri_len - 1] != '/') {
+		uri_len = (int)strlen(ri->local_uri);
+		if (file.is_directory && uri_len > 0
+		    && ri->local_uri[uri_len - 1] != '/') {
 			gmt_time_string(date, sizeof(date), &curtime);
 			mg_printf(conn,
 			          "HTTP/1.1 301 Moved Permanently\r\n"


### PR DESCRIPTION
`uri_len` update is needed after the process 1.2. or 1.3. of `handle_request()`.