### PR TITLE
Changing c++ library name to 'civetweb-cpp'

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -266,26 +266,26 @@ endif()
 
 # The C++ API library
 if (CIVETWEB_ENABLE_CXX)
-  add_library(cxx-library CivetServer.cpp)
-  set_target_properties(cxx-library PROPERTIES
-    OUTPUT_NAME "cxx-library"
+  add_library(civetweb-cpp CivetServer.cpp)
+  set_target_properties(civetweb-cpp PROPERTIES
+    OUTPUT_NAME "civetweb-cpp"
     VERSION ${CIVETWEB_VERSION}
     SOVERSION ${CIVETWEB_VERSION}
   )
   if (BUILD_SHARED_LIBS)
-    target_compile_definitions(cxx-library PRIVATE CIVETWEB_DLL_EXPORTS)
+    target_compile_definitions(civetweb-cpp PRIVATE CIVETWEB_DLL_EXPORTS)
   endif()
   target_include_directories(
-    cxx-library PUBLIC
+    civetweb-cpp PUBLIC
     ${PROJECT_SOURCE_DIR}/include)
   install(
-    TARGETS cxx-library
+    TARGETS civetweb-cpp
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
-    COMPONENT cxx-library)
+    COMPONENT civetweb-cpp)
   install(FILES
     ${PROJECT_SOURCE_DIR}/include/CivetServer.h
     DESTINATION include
-    COMPONENT cxx-library)
+    COMPONENT civetweb-cpp)
 endif()

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -14435,6 +14435,10 @@ mg_check_feature(unsigned feature)
 int
 mg_print_system_info(int prm1, char *prm2)
 {
+    //WARNING: these parameters are not being used
+	(void)prm1;
+	(void)prm2;
+	
 	const char *version = mg_version();
 #if defined(_WIN32)
 #if !defined(__SYMBIAN32__)
@@ -14454,9 +14458,6 @@ mg_print_system_info(int prm1, char *prm2)
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-
-	(void)prm1;
-	(void)prm2;
 
 	dwMajorVersion = (DWORD)(LOBYTE(LOWORD(dwVersion)));
 	dwMinorVersion = (DWORD)(HIBYTE(LOWORD(dwVersion)));

--- a/src/main.c
+++ b/src/main.c
@@ -864,7 +864,9 @@ start_civetweb(int argc, char *argv[])
 	 * This is very useful for diagnosis. */
 	if (argc > 1 && !strcmp(argv[1], "-I")) {
 
+#ifdef WIN32
 		(void)MakeConsole();
+#endif
 		fprintf(stdout, "\n%s (%s)\n", g_server_base_name, g_server_name);
 		(void)mg_print_system_info(0, 0);
 


### PR DESCRIPTION
Changed the name used on build to the c++ wrapper library to something more related to the project.

Made  some minor fixes to avoid build errors.