### PR TITLE
Documentation: Clarified usage of PREFIX option for Makefile

### DIFF
--- a/docs/Building.md
+++ b/docs/Building.md
@@ -103,6 +103,33 @@ make build WITH_LUA=1
 Note that the WITH_* options used for *make* are not identical to the
 preprocessor defines in the source code - usually USE_* is used there.
 
+## Changing PREFIX
+
+To change the target destination pass the `PREFIX` option to the command `make install` (not `make build`). Example usage:
+
+```
+$ make build
+$ make -n install PREFIX=/opt/civetweb
+```
+Note: The `-n` corresponds to the `--dry-run` option (it does not make any changes): You can see where `make install` would install. Example output of the above command:
+
+```
+$ make -n install PREFIX=/opt/civetweb
+install -d -m 755  "/opt/civetweb/share/doc/civetweb"
+install -m 644 resources/itworks.html /opt/civetweb/share/doc/civetweb/index.html
+install -m 644 resources/civetweb_64x64.png /opt/civetweb/share/doc/civetweb/
+install -d -m 755  "/opt/civetweb/etc"
+install -m 644 resources/civetweb.conf  "/opt/civetweb/etc/"
+sed -i 's#^document_root.*$#document_root /opt/civetweb/share/doc/civetweb#' "/opt/civetweb/etc/civetweb.conf"
+sed -i 's#^listening_ports.*$#listening_ports 8080#' "/opt/civetweb/etc/civetweb.conf"
+install -d -m 755  "/opt/civetweb/share/doc/civetweb"
+install -m 644 *.md "/opt/civetweb/share/doc/civetweb"
+install -d -m 755 "/opt/civetweb/bin"
+install -m 755 civetweb "/opt/civetweb/bin/"
+```
+
+If the output looks good: Just remove the `-n` option to actually install the software on your system.
+
 ## Setting compile flags
 
 Compile flags can be set using the *COPT* make option like so.


### PR DESCRIPTION
Not having used Makefiles in a while, the docs where unclear to me on the usage of the PREFIX option.

Here is what I tried until I found the solution:

Trial 1: This is what I expected to work from reading the docs:
```
$ make build PREFIX=/opt/civetweb WITH_LUA=1 WITH_WEBSOCKET=1
$ make -n install

install -d -m 755  "/usr/local/share/doc/civetweb"
install -m 644 resources/itworks.html /usr/local/share/doc/civetweb/index.html
install -m 644 resources/civetweb_64x64.png /usr/local/share/doc/civetweb/
install -d -m 755  "/usr/local/etc"
install -m 644 resources/civetweb.conf  "/usr/local/etc/"
sed -i 's#^document_root.*$#document_root /usr/local/share/doc/civetweb#' "/usr/local/etc/civetweb.conf"
sed -i 's#^listening_ports.*$#listening_ports 8080#' "/usr/local/etc/civetweb.conf"
install -d -m 755  "/usr/local/share/doc/civetweb"
install -m 644 *.md "/usr/local/share/doc/civetweb"
install -d -m 755 "/usr/local/bin"
install -m 755 civetweb "/usr/local/bin/"
```
Trial 2: Trial and error:
```
$ PREFIX=/opt/civetweb make build WITH_LUA=1 WITH_WEBSOCKET=1
$ make -n install
install -d -m 755  "/usr/local/share/doc/civetweb"
install -m 644 resources/itworks.html /usr/local/share/doc/civetweb/index.html
install -m 644 resources/civetweb_64x64.png /usr/local/share/doc/civetweb/
install -d -m 755  "/usr/local/etc"
install -m 644 resources/civetweb.conf  "/usr/local/etc/"
sed -i 's#^document_root.*$#document_root /usr/local/share/doc/civetweb#' "/usr/local/etc/civetweb.conf"
sed -i 's#^listening_ports.*$#listening_ports 8080#' "/usr/local/etc/civetweb.conf"
install -d -m 755  "/usr/local/share/doc/civetweb"
install -m 644 *.md "/usr/local/share/doc/civetweb"
install -d -m 755 "/usr/local/bin"
install -m 755 civetweb "/usr/local/bin/"
```

Trial 3: Finally ;-)
```
$ make build WITH_LUA=1 WITH_WEBSOCKET=1
$ make -n install PREFIX=/opt/civetweb 
install -d -m 755  "/opt/civetweb/share/doc/civetweb"
install -m 644 resources/itworks.html /opt/civetweb/share/doc/civetweb/index.html
install -m 644 resources/civetweb_64x64.png /opt/civetweb/share/doc/civetweb/
install -d -m 755  "/opt/civetweb/etc"
install -m 644 resources/civetweb.conf  "/opt/civetweb/etc/"
sed -i 's#^document_root.*$#document_root /opt/civetweb/share/doc/civetweb#' "/opt/civetweb/etc/civetweb.conf"
sed -i 's#^listening_ports.*$#listening_ports 8080#' "/opt/civetweb/etc/civetweb.conf"
install -d -m 755  "/opt/civetweb/share/doc/civetweb"
install -m 644 *.md "/opt/civetweb/share/doc/civetweb"
install -d -m 755 "/opt/civetweb/bin"
install -m 755 civetweb "/opt/civetweb/bin/"
```

My PR just ads a sub section to the build documentation.