### PR TITLE
fix include directory for openssl

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 
 # We need to link OpenSSL if not dynamically loading
 if (CIVETWEB_ENABLE_SSL)
+  include_directories(${OPENSSL_INCLUDE_DIR})
   if (CIVETWEB_ENABLE_SSL_DYNAMIC_LOADING)
     find_package(LibDl)
     if (LIBDL_FOUND)


### PR DESCRIPTION
Previsously the include of OpenSSL worked a little by accident (the
default /usr/include directory being there). On system where two versions
of OpenSSL can cohabite (for example FreeBSD), issues can occur in the
form of including one version (the one in /usr/include) and
linking against another (the one /usr/local/include|lib).

The issue can be reproduced on FreeBSD 11 with the openssl-devel package
installed. FindPackage(OpenSSL) recovers 1.1.0, with directories /usr/local/include|lib),
linkage is set to this version, but lack of proper include meant that the openssl lib from the
basesystem (1.0.2, header in /usr/include/) is used to try compiling.