### PR TITLE
Allow compiling as C++.

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -8565,7 +8565,7 @@ prepare_cgi_environment(struct mg_connection *conn,
 			addenv(env, "SCRIPT_NAME=%s", conn->request_info.local_uri);
 		} else {
 			/* URI: /path_to_script/ ... using index.cgi */
-			char *index_file = strrchr(prog, '/');
+			const char *index_file = strrchr(prog, '/');
 			if (index_file) {
 				addenv(env,
 				       "SCRIPT_NAME=%s%s",
@@ -13195,7 +13195,8 @@ static int
 get_uri_type(const char *uri)
 {
 	int i;
-	char *hostend, *portbegin, *portend;
+	const char *hostend, *portbegin;
+	char *portend;
 	unsigned long port;
 
 	/* According to the HTTP standard
@@ -14904,7 +14905,7 @@ mg_start(const struct mg_callbacks *callbacks,
 
 	/* Start worker threads */
 	for (i = 0; i < ctx->cfg_worker_threads; i++) {
-		struct worker_thread_args *wta =
+		struct worker_thread_args *wta = (struct worker_thread_args *)
 		    mg_malloc(sizeof(struct worker_thread_args));
 		if (wta) {
 			wta->ctx = ctx;

--- a/src/handle_form.inl
+++ b/src/handle_form.inl
@@ -90,7 +90,7 @@ url_encoded_field_get(const struct mg_connection *conn,
 {
 	char key_dec[1024];
 
-	char *value_dec = mg_malloc(value_len + 1);
+	char *value_dec = (char*)mg_malloc(value_len + 1);
 	int value_dec_len, ret;
 
 	if (!value_dec) {
@@ -521,8 +521,8 @@ mg_handle_form_request(struct mg_connection *conn,
 		size_t bl;
 		ptrdiff_t used;
 		struct mg_request_info part_header;
-		char *hbuf, *hend, *fbeg, *fend, *nbeg, *nend;
-		const char *content_disp;
+		char *hbuf;
+		const char *content_disp, *hend, *fbeg, *fend, *nbeg, *nend;
 		const char *next;
 
 		memset(&part_header, 0, sizeof(part_header));


### PR DESCRIPTION
I prefer to compile civetweb.c as C++, so I can share the same precompiled header with the rest of my code.  This used to work with Civetweb version 1.7.
I know civetweb.c is a C program, but I see no harm in enforcing the extra type safety and const correctness required for C++.
In Visual Studio 2015 this is Properties -> C++ -> Advanced -> Compile As, or /TP on the command line.