### PR TITLE
Add general usercontext variable to CPP server

### DIFF
--- a/include/CivetServer.h
+++ b/include/CivetServer.h
@@ -531,6 +531,10 @@ class CIVETWEB_API CivetServer
 	                      std::string &dst,
 	                      bool append = false);
 
+        // generic user context which can be set/read,
+        // the server does noting with this apart form keep it.
+        void *UserContext;
+        
   protected:
 	class CivetConnection
 	{

--- a/include/CivetServer.h
+++ b/include/CivetServer.h
@@ -227,9 +227,11 @@ class CIVETWEB_API CivetServer
 	 * @throws CivetException
 	 */
 	CivetServer(const char **options,
-	            const struct CivetCallbacks *callbacks = 0);
+	            const struct CivetCallbacks *callbacks = 0,
+                    const void *UserContext = 0);
 	CivetServer(std::vector<std::string> options,
-	            const struct CivetCallbacks *callbacks = 0);
+	            const struct CivetCallbacks *callbacks = 0,
+                    const void *UserContext = 0);
 
 	/**
 	 * Destructor
@@ -532,8 +534,11 @@ class CIVETWEB_API CivetServer
 	                      bool append = false);
 
         // generic user context which can be set/read,
-        // the server does noting with this apart form keep it.
-        void *UserContext;
+        // the server does nothing with this apart from keep it.
+	const void *getUserContext() const
+	{
+		return UserContext;
+	}
         
   protected:
 	class CivetConnection
@@ -548,6 +553,10 @@ class CIVETWEB_API CivetServer
 
 	struct mg_context *context;
 	std::map<struct mg_connection *, class CivetConnection> connections;
+
+        // generic user context which can be set/read,
+        // the server does nothing with this apart from keep it.
+        const void *UserContext;
 
   private:
 	/**

--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -269,11 +269,14 @@ CivetCallbacks::CivetCallbacks()
 }
 
 CivetServer::CivetServer(const char **options,
-                         const struct CivetCallbacks *_callbacks)
+                         const struct CivetCallbacks *_callbacks,
+                         const void *UserContextIn)
     : context(0)
 {
 	struct CivetCallbacks callbacks;
 
+        UserContext = UserContextIn;
+        
 	if (_callbacks) {
 		callbacks = *_callbacks;
 		userCloseHandler = _callbacks->connection_close;
@@ -288,10 +291,13 @@ CivetServer::CivetServer(const char **options,
 }
 
 CivetServer::CivetServer(std::vector<std::string> options,
-                         const struct CivetCallbacks *_callbacks)
+                         const struct CivetCallbacks *_callbacks,
+                         const void *UserContextIn)
     : context(0)
 {
 	struct CivetCallbacks callbacks;
+        
+        UserContext = UserContextIn;
 
 	if (_callbacks) {
 		callbacks = *_callbacks;
@@ -576,7 +582,7 @@ CivetServer::getListeningPorts()
 	std::vector<int> ports(50);
 	std::vector<struct mg_server_ports> server_ports(50);
 	int size =
-	    mg_get_server_ports(context, server_ports.size(), &server_ports[0]);
+	    mg_get_server_ports(context, (int)server_ports.size(), &server_ports[0]);
 	if (size <= 0) {
 		ports.resize(0);
 		return ports;


### PR DESCRIPTION
When I'm using CivetServer.cpp, a usercontext variable in the class is useful....  nothing in the class references it, but it is publicly accessible.
If you think this should be done by other means (e.g. deriving a class), just close this request :).