### PR TITLE
Fix bash path in shebangs

### DIFF
--- a/ci/travis/install_rocks.sh
+++ b/ci/travis/install_rocks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ev
 
 source ci/travis/lua_env.sh

--- a/ci/travis/lua_env.sh
+++ b/ci/travis/lua_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 LUAROCKS=ci/lua/bin/luarocks
 eval $($LUAROCKS path --bin)

--- a/ci/travis/run_ci_tests.sh
+++ b/ci/travis/run_ci_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ev
 
 source ci/travis/lua_env.sh

--- a/ci/travis/setup_lua.sh
+++ b/ci/travis/setup_lua.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env /bash
 set -ev
 
 # this script installs a lua / luarocks environment in .travis/lua


### PR DESCRIPTION
"/bin/bash" is a Linuxism.  "/usr/bin/env bash" is portable.