### PR TITLE
Allow disabling executable install.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,11 @@ message(STATUS "Force x32 / x64 architecture - ${CIVETWEB_ARCH}")
 option(CIVETWEB_ENABLE_LUA "Enable Lua CGIs" OFF)
 message(STATUS "Lua CGI support - ${CIVETWEB_ENABLE_LUA}")
 
+# Enable installing CivetWeb executables
+option(CIVETWEB_INSTALL_EXECUTABLE "Enable installing CivetWeb executable" ON)
+mark_as_advanced(FORCE CIVETWEB_INSTALL_EXECUTABLE) # Advanced users can disable
+message(STATUS "Executable installation - ${CIVETWEB_INSTALL_EXECUTABLE}") 
+
 # Allow builds to complete with warnings (do not set -Werror)
 if (LINUX)
 # CivetWeb Linux support is stable: Builds must be free from warnings.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -233,12 +233,14 @@ add_executable(c-executable main.c)
 set_target_properties(c-executable PROPERTIES
   OUTPUT_NAME "civetweb"
 )
-install(
-  TARGETS c-executable
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-  COMPONENT server)
+if (CIVETWEB_INSTALL_EXECUTABLE)
+  install(
+    TARGETS c-executable
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+    COMPONENT server)
+endif()
 if (BUILD_SHARED_LIBS)
   target_compile_definitions(c-executable PRIVATE CIVETWEB_DLL_IMPORTS)
 endif()
@@ -265,7 +267,7 @@ if (CIVETWEB_ENABLE_LUA)
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
-    COMPONENT lua-library)  
+    COMPONENT lua-library)
 endif()
 
 # The C++ API library


### PR DESCRIPTION
This keeps previous functionality by having executable installation on by
default. It also tries to mitigate the ability to "screw it up" by only
allowing users that have made themselves advanced to disable installing
the executable.

See: https://cmake.org/cmake/help/v3.9/command/mark_as_advanced.html

Closes #505.