### PR TITLE
Background lua script moved from main thread to external thread

### DIFF
--- a/src/mod_lua.inl
+++ b/src/mod_lua.inl
@@ -85,13 +85,24 @@ reg_llstring(struct lua_State *L,
 {
 	if (buffer1 != NULL && buffer2 != NULL) {
 		lua_pushlstring(L, (const char *)buffer1, buflen1);
-		lua_pushlstring(L, (const char *)buffer1, buflen2);
+		lua_pushlstring(L, (const char *)buffer2, buflen2);
 		lua_rawset(L, -3);
 	}
 }
 
 #define reg_string(L, name, val)                                               \
 	reg_lstring(L, name, val, val ? strlen(val) : 0)
+
+static void
+reg_ludata( struct lua_State *L, const char *name, void* val)
+{
+	if ( name != NULL )
+	{
+		lua_pushstring( L, name );
+		lua_pushlightuserdata( L, val );
+		lua_rawset( L, -3 );
+	}
+}
 
 static void
 reg_int(struct lua_State *L, const char *name, int val)

--- a/test/background.lua
+++ b/test/background.lua
@@ -1,0 +1,48 @@
+----------------------------------------------
+-- Lua background script example
+-- Global table    - mg
+--
+-- Fields in table 
+--
+-- 	mg.isterminated - true if background script need exit
+-- 	mg.log          - send message to stdout
+-- 	mg.handler      - thread handler, light userdata
+-- 	mg.sleep        - sleep thread for milliseconds
+-- 	mg.params       - store lua_background_script_params config values
+--	mg.script       - script name
+--      mg.root         - document roots directory
+
+-- Comment
+-- lua_background_script         - background.lua
+-- lua_background_script_params  - param1=1,run_mode=database etc
+-- background script terminated after all client socket closed
+----------------------------------------------
+
+local run_once = false
+
+local mg       = mg
+local thandler = mg.handler
+local params   = mg.params
+
+-- Script run once, lua_state closed when exit from script
+if ( run_once ) then
+	halt(0)
+end 
+
+
+-- Parameter test
+-- Parameter format in lua_background_script_params : exit=1,param1=2
+if ( params ~= nil and params.exit == "1" ) then
+	halt(0)
+end
+
+mg.log(thandler ,"Background script running")
+while ( true) do
+	if ( mg.isterminated(thandler ) )
+	then
+		mg.log(thandler ,"Background script terminated by main thread")
+		break
+	end
+	mg.sleep(500)
+end
+mg.log(thandler,"Background script shutdown")


### PR DESCRIPTION
The background script old behivor, fully frezee the main thread while script not finished.
In this version, main thread start new background script thread.
When server is closed, background script receive terminate signal and exit, or run once and lua state closed.
- Added some thread specific calling, like sleep, root dir, script name.
- Background script example attached.
- Documentation is not upgraded, my english is not well.
