### PR TITLE
Fixed README.md "OSX->macOS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![GitHub contributors](https://img.shields.io/github/contributors/civetweb/civetweb.svg)](https://github.com/civetweb/civetweb/blob/master/CREDITS.md)
 
-Continuous integration for Linux and OSX ([Travis CI](https://travis-ci.org/civetweb/civetweb)):
+Continuous integration for Linux and macOS ([Travis CI](https://travis-ci.org/civetweb/civetweb)):
 
 [![Travis Build Status](https://travis-ci.org/civetweb/civetweb.svg?branch=master)](https://travis-ci.org/civetweb/civetweb)
 


### PR DESCRIPTION
I fixed README.md.
[link here](https://www.wired.com/2016/06/apple-os-x-dead-long-live-macos/)
For Apple changed the original name "Mac OS X" to "OS X" in 2012 and then to "macOS" in 2016.
In the document I think should be better to modify.