### PR TITLE
Fix about PATH_MAX

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -4833,8 +4833,8 @@ mg_opendir(const struct mg_connection *conn, const char *name)
 	} else {
 		path_to_unicode(conn, name, wpath, ARRAY_SIZE(wpath));
 		attrs = GetFileAttributesW(wpath);
-		if (attrs != 0xFFFFFFFF && ((attrs & FILE_ATTRIBUTE_DIRECTORY)
-		                            == FILE_ATTRIBUTE_DIRECTORY)) {
+		if ((wcslen(wpath) + 2 < ARRAY_SIZE(wpath)) && (attrs != 0xFFFFFFFF)
+		    && ((attrs & FILE_ATTRIBUTE_DIRECTORY) != 0)) {
 			(void)wcscat(wpath, L"\\*");
 			dir->handle = FindFirstFileW(wpath, &dir->info);
 			dir->result.d_name[0] = '\0';


### PR DESCRIPTION
The second 664d7af6eac17833c55fa18aadb1440bbcc496b0 is optional. If you don't want, I'll remove it.
For CJK languages, 260(MAX_PATH) bytes in UTF-8 are only 86 elements in wchar_t. Sometimes I suffer this limit.