### PR TITLE
#394: static_assert on Windows with Clang

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -77,12 +77,10 @@
 /* This code uses static_assert to check some conditions.
  * Unfortunately some compilers still do not support it, so we have a
  * replacement function here. */
-#if defined(_MSC_VER) && (_MSC_VER >= 1600)
-#define mg_static_assert static_assert
-#elif defined(__cplusplus) && (__cplusplus >= 201103L)
-#define mg_static_assert static_assert
-#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ > 201100L
 #define mg_static_assert _Static_assert
+#elif defined(__cplusplus) && __cplusplus >= 201103L
+#define mg_static_assert static_assert
 #else
 char static_assert_replacement[1];
 #define mg_static_assert(cond, txt)                                            \


### PR DESCRIPTION
When C11 is available, use [`_Static_assert`](http://en.cppreference.com/w/c/language/_Static_assert).
Otherwise, if C++11 is available, use ['static_assert'](http://en.cppreference.com/w/cpp/language/static_assert).
Finally, fallback on the custom array-index based implementation.