### PR TITLE
Fix truncation check in (deprecated) mg_upload_field_found() function.

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -12072,7 +12072,7 @@ mg_upload_field_found(const char *key,
 	            "%s/%s",
 	            fud->destination_dir,
 	            filename);
-	if (!truncated) {
+	if (truncated) {
 		mg_cry(fud->conn, "%s: File path too long", __func__);
 		return FORM_FIELD_STORAGE_ABORT;
 	}

--- a/src/handle_form.inl
+++ b/src/handle_form.inl
@@ -473,6 +473,10 @@ mg_handle_form_request(struct mg_connection *conn,
 						r = mg_read(conn, buf + (size_t)buf_fill, to_read);
 						if (r < 0) {
 							/* read error */
+							if (fstore.access.fp) {
+								mg_fclose(&fstore.access);
+								remove_bad_file(conn, path);
+							}
 							return -1;
 						}
 						if (r != (int)to_read) {
@@ -869,6 +873,10 @@ mg_handle_form_request(struct mg_connection *conn,
 				            sizeof(buf) - 1 - (size_t)buf_fill);
 				if (r < 0) {
 					/* read error */
+					if (fstore.access.fp) {
+						mg_fclose(&fstore.access);
+						remove_bad_file(conn, path);
+					}
 					mg_free(boundary);
 					return -1;
 				}
@@ -876,6 +884,10 @@ mg_handle_form_request(struct mg_connection *conn,
 				buf[buf_fill] = 0;
 				if (buf_fill < 1) {
 					/* No data */
+					if (fstore.access.fp) {
+						mg_fclose(&fstore.access);
+						remove_bad_file(conn, path);
+					}
 					mg_free(boundary);
 					return -1;
 				}


### PR DESCRIPTION
The logic is inverted here. If 'truncated' has been set to 'true' by mg_snprintf(), then it means the file path was too long.