### PR TITLE
Adds static method to get post data from CivetServer

### DIFF
--- a/include/CivetServer.h
+++ b/include/CivetServer.h
@@ -450,6 +450,18 @@ class CIVETWEB_API CivetServer
 	                     size_t occurrence = 0);
 
 	/**
+	 * getPostData(struct mg_connection *)
+	 *
+	 * Returns response body from a request made as POST. Since the
+	 * connections map is protected, it can't be directly accessed.
+	 * This uses string to store post data to handle big posts.
+	 *
+	 * @param conn - connection from which post data will be read
+	 * @return Post data (empty if not avaliable).
+	 */
+     static std::string getPostData(struct mg_connection *conn);
+     
+	/**
 	 * urlDecode(const std::string &, std::string &, bool)
 	 *
 	 * @param src - string to be decoded

--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -546,6 +546,25 @@ CivetServer::getParam(const char *data,
 	return false;
 }
 
+std::string
+CivetServer::getPostData(struct mg_connection *conn)
+{
+	const struct mg_request_info *ri = mg_get_request_info(conn);
+	assert(ri != NULL);
+	CivetServer *me = (CivetServer *)(ri->user_data);
+	assert(me != NULL);
+	mg_lock_context(me->context);
+	CivetConnection &conobj = me->connections[conn];
+	mg_lock_connection(conn);
+	mg_unlock_context(me->context);
+	std::string postdata;
+	postdata.resize(conobj.postDataLen);
+	memcpy(&postdata[0],conobj.postData,conobj.postDataLen);
+	postdata += '\0';
+	mg_unlock_connection(conn);
+	return postdata;
+}
+
 void
 CivetServer::urlEncode(const char *src, std::string &dst, bool append)
 {


### PR DESCRIPTION
I'm using civetweb with JSON requests/responses, so I needed to access the response body directly. I know that the C API can handle it pretty well, but lately I've been using the C++ classes. And either I can't find it or there isn't a clear method to retrieve it.

So I added this small part of code. Since "connections" map is protected, I can access connection post data only by a static method.

I've used this for the several past weeks even in production. I honestly didn't run the C tests because this affects the C++ interface. Does it have test routines for this too?

Thanks!