### PR TITLE
Changed method getPostData from CivetServer to a more robust method

### DIFF
--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -549,18 +549,16 @@ CivetServer::getParam(const char *data,
 std::string
 CivetServer::getPostData(struct mg_connection *conn)
 {
-	const struct mg_request_info *ri = mg_get_request_info(conn);
-	assert(ri != NULL);
-	CivetServer *me = (CivetServer *)(ri->user_data);
-	assert(me != NULL);
-	mg_lock_context(me->context);
-	CivetConnection &conobj = me->connections[conn];
 	mg_lock_connection(conn);
-	mg_unlock_context(me->context);
 	std::string postdata;
-	postdata.resize(conobj.postDataLen);
-	memcpy(&postdata[0],conobj.postData,conobj.postDataLen);
-	postdata += '\0';
+	char buf[2048];
+	int r = mg_read(conn, buf, sizeof(buf));
+	while (r > 0) {
+		std::string p = std::string(buf);
+		p.resize(r);
+		postdata += p;
+		r = mg_read(conn, buf, sizeof(buf));
+	}
 	mg_unlock_connection(conn);
 	return postdata;
 }


### PR DESCRIPTION
The old method seems to break if post data is too large or has some strange chars. This one is more stable and C++ like.