### PR TITLE
Fixed a lot of misspellings in source code and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ help:
 	@echo "   NO_SSL                disable SSL functionality"
 	@echo "   NO_SSL_DL             link against system libssl library"
 	@echo "   NO_FILES              do not serve files from a directory"
-	@echo "   NO_CACHING            disable caching (usefull for systems without timegm())"
+	@echo "   NO_CACHING            disable caching (useful for systems without timegm())"
 	@echo ""
 	@echo " Variables"
 	@echo "   TARGET_OS='$(TARGET_OS)'"

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Contributions are welcome provided all contributions carry the MIT license.
 
 DO NOT APPLY fixes copied from Mongoose to this project to prevent GPL tainting.
 Since 2013, CivetWeb and Mongoose are developed independently.
-By now the code base differs, so patches cannot be safely transfered in either direction.
+By now the code base differs, so patches cannot be safely transferred in either direction.
 
 Some guidelines can be found in [docs/Contribution.md](https://github.com/civetweb/civetweb/blob/master/docs/Contribution.md).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -51,7 +51,7 @@ Changes
 - Support for multipart requests without quotes (for some C# clients)
 - Initialize SSL in mg\_init\_library, so https client functions can be used when no server is running
 - Allow "REPORT" HTTP method for REST calls to scripts
-- Allow to compile civetweb.c wih a C++ compiler
+- Allow to compile civetweb.c with a C++ compiler
 - Lua: Remove internal length limits of encode/decode functions
 - Allow sub-resources of index script files
 - Add config parameter allow\_index\_script\_resource the aforementioned feature
@@ -406,6 +406,6 @@ Changes
 
 - Renamed Mongoose to Civetweb in the code and documentation.
 - Replaced copyrighted images with new images
-- Created a new code respository at https://github.com/civetweb/civetweb
+- Created a new code repository at https://github.com/civetweb/civetweb
 - Created a distribution site at https://sourceforge.net/projects/civetweb/
 - Basic build testing

--- a/ci/test/README.md
+++ b/ci/test/README.md
@@ -8,7 +8,7 @@ I have fixed and extended the travis configuration to build on the new sudo-less
 
 * On Check-in or Pull Requests clone the repo
 * Run make WITH_LUA=1 WITH_DEBUG=1 WITH_IPV6=1 WITH_WEBSOCKET=1
-* Build a standalone lua installation (seperate from civetweb or the OS)
+* Build a standalone lua installation (separate from civetweb or the OS)
 * Build LuaRocks in standalone installation
 * Install a few rocks into the standalone installation
 * Start the test script

--- a/docs/APIReference.md
+++ b/docs/APIReference.md
@@ -12,7 +12,7 @@ examples directory.
 
 | Macro | Description |
 | :--- | :--- |
-| **`CIVETWEB_VERSION`** | The current version of the software as a string with the major and minor version number seperated with a dot. For version 1.9, this string will have the value "1.9", for thw first patch of this version "1.9.1". |
+| **`CIVETWEB_VERSION`** | The current version of the software as a string with the major and minor version number separated with a dot. For version 1.9, this string will have the value "1.9", for thw first patch of this version "1.9.1". |
 | **`CIVETWEB_VERSION_MAJOR`** | The current major version as number, e.g., (1) for version 1.9. |
 | **`CIVETWEB_VERSION_MINOR`** | The current minor version as number, e.g., (9) for version 1.9. |
 | **`CIVETWEB_VERSION_PATCH`** | The current patch version as number, e.g., (0) for version 1.9 or (1) for version 1.9.1. |

--- a/docs/Embedding.md
+++ b/docs/Embedding.md
@@ -71,8 +71,8 @@ By default, the server will automatically serve up files like a normal HTTP serv
     Not all CivetWeb features available in C are also available in C++.
   - Create CivetHandlers for each URI.
   - Register the handlers with `CivetServer::addHandler()`
-  - `CivetServer` starts on contruction and stops on destruction.
-  - Use contructor *options* to select the port and document root among other things.
+  - `CivetServer` starts on construction and stops on destruction.
+  - Use constructor *options* to select the port and document root among other things.
   - Use constructor *callbacks* to add your own hooks.
 
 Alternative quick start: Have a look at the examples embedded\_c and embedded\_cpp

--- a/docs/UserManual.md
+++ b/docs/UserManual.md
@@ -165,7 +165,7 @@ of code throughout a website, for example, headers and footers.
 
 In order for a webpage to recognize an SSI-enabled HTML file, the filename
 should end with a special extension, by default the extension should be
-either `.shtml` or `.shtm`. These extentions may be changed using the
+either `.shtml` or `.shtm`. These extensions may be changed using the
 `ssi_pattern` option.
 
 Unknown SSI directives are silently ignored by CivetWeb. Currently, two SSI
@@ -505,7 +505,7 @@ The error pages may be specified for an individual http status code (e.g.,
 404 - page requested by the client not found), a group of http status codes
 (e.g., 4xx - all client errors) or all errors. The corresponding error pages
 must be called error404.ext, error4xx.ext or error.ext, whereas the file
-extention may be one of the extentions specified for the index_files option.
+extension may be one of the extensions specified for the index_files option.
 See the [Wikipedia page on HTTP status codes](http://en.wikipedia.org/wiki/HTTP_status_code).
 
 ### tcp\_nodelay `0`

--- a/docs/api/mg_callbacks.md
+++ b/docs/api/mg_callbacks.md
@@ -9,7 +9,7 @@
 |**`begin_request`**|**`int (*begin_request)( struct mg_connection *conn );`**|
 | |The `begin_request()` callback function is called when CivetWeb has received a new HTTP request. If the callback function does not process the request, it should return 0. In that case CivetWeb will handle the request with the default callback routine. If the callback function returns a value between 1 and 999, CivetWeb does nothing and the callback function should do all the processing, including sending the proper HTTP headers etc. Starting at CivetWeb version 1.7, the function `begin_request()` is called before any authorization is done. If an authorization check is required, `request_handler()` should be used instead. The return value of the callback function is not only used to signal CivetWeb to not further process the request. The returned value is also stored as HTTP status code in the access log. |
 |**`connection_close`**|**`void (*connection_close)( const struct mg_connection *conn );`**|
-| |The callback function `connection_close()` is called when CivetWeb is closing a connection. The per-context mutex is locked when the callback function is invoked. The function is primarly useful for noting when a websocket is closing and removing it from any application-maintained list of clients. *Using this callback for websocket connections is deprecated. Use* `mg_set_websocket_handler()` *instead.*|
+| |The callback function `connection_close()` is called when CivetWeb is closing a connection. The per-context mutex is locked when the callback function is invoked. The function is primarily useful for noting when a websocket is closing and removing it from any application-maintained list of clients. *Using this callback for websocket connections is deprecated. Use* `mg_set_websocket_handler()` *instead.*|
 |**`end_request`**|**`void (*end_request)(const struct mg_connection *conn, int reply_status_code);`**|
 | |The callback function `end_request()` is called by CivetWeb when a request has been completely processed. It sends the reply status code which was sent to the client to the application.|
 |**`exit_context`**|**`void (*exit_context)( const struct mg_context *ctx );`**|
@@ -46,7 +46,7 @@
 | | **`data_len`** - The length of the received data block |
 | | If the application wants to keep the websocket open to receive more data, the callback function should return the value **1**. If the value **0** is returned by the callback function, CivetWeb will close the websocket connection and no more frames will be received.|
 |~~`websocket_ready`~~|**`int (*websocket_ready)( struct mg_connection *conn );`**|
-| |*Deprecated. Use* `mg_set_websocket_handler()` *instead.* The callback function `websocket_ready()` is called after the handshake of a websocket connection has succeeded succesfully to signal the application that the connection is ready for use. |
+| |*Deprecated. Use* `mg_set_websocket_handler()` *instead.* The callback function `websocket_ready()` is called after the handshake of a websocket connection has succeeded successfully to signal the application that the connection is ready for use. |
 
 ### Description
 

--- a/docs/api/mg_cry.md
+++ b/docs/api/mg_cry.md
@@ -6,7 +6,7 @@
 
 | Parameter | Type | Description |
 | :--- | :--- | :--- |
-|**`conn`**|`const struct mg_connection *`|The connection on which a problem occured|
+|**`conn`**|`const struct mg_connection *`|The connection on which a problem occurred|
 |**`fmt`**|`const char *`|Format string without a line return|
 |**`...`**|*various*|Parameters depending on the format string|
 

--- a/docs/api/mg_get_header.md
+++ b/docs/api/mg_get_header.md
@@ -17,6 +17,6 @@
 
 ### Description
 
-HTTP and HTTPS clients can send request headers to the server to provide details about the communication. These request headers can for example specify the preferred language in which the server should respond and the supported compression algorithms. The function `mg_get_header()` can be called to return the contents of a specific request header. The function will return a pointer to the value text of the header when succesful, and NULL of no matching request header from the client could be found.
+HTTP and HTTPS clients can send request headers to the server to provide details about the communication. These request headers can for example specify the preferred language in which the server should respond and the supported compression algorithms. The function `mg_get_header()` can be called to return the contents of a specific request header. The function will return a pointer to the value text of the header when successful, and NULL of no matching request header from the client could be found.
 
 ### See Also

--- a/docs/api/mg_get_option.md
+++ b/docs/api/mg_get_option.md
@@ -13,11 +13,11 @@
 
 | Type | Description |
 | :--- | :--- |
-|`const char *`| A pointer to the option value in text, or NULL if an error occured |
+|`const char *`| A pointer to the option value in text, or NULL if an error occurred |
 
 ### Description
 
-When starting the CivetWeb webserver, options are provided to set the wanted behaviour of the server. The options which were used during startup can be queried through the `mg_get_option()` function. Options are read-only and cannot be changed while the webserver is running. The function returns a pointer to a text string containing the value of the queried option, or NULL if an error occured. It is guaranteed however that if a valid option name is provided as a parameter to this function, that a pointer to a string is returned and not NULL. In case an option was empty or NULL during initialisation, `mg_get_option()` will return a pointer to an empty string.
+When starting the CivetWeb webserver, options are provided to set the wanted behaviour of the server. The options which were used during startup can be queried through the `mg_get_option()` function. Options are read-only and cannot be changed while the webserver is running. The function returns a pointer to a text string containing the value of the queried option, or NULL if an error occurred. It is guaranteed however that if a valid option name is provided as a parameter to this function, that a pointer to a string is returned and not NULL. In case an option was empty or NULL during initialisation, `mg_get_option()` will return a pointer to an empty string.
 
 ### See Also
 

--- a/docs/api/mg_get_request_info.md
+++ b/docs/api/mg_get_request_info.md
@@ -12,7 +12,7 @@
 
 | Type | Description |
 | :--- | :--- |
-|`const struct mg_request_info *`|Pointer to the requested info, or NULL if an error occured|
+|`const struct mg_request_info *`|Pointer to the requested info, or NULL if an error occurred|
 
 ### Description
 

--- a/docs/api/mg_get_response_info.md
+++ b/docs/api/mg_get_response_info.md
@@ -12,7 +12,7 @@
 
 | Type | Description |
 | :--- | :--- |
-|`const struct mg_request_info *`|Pointer to the requested info, or NULL if an error occured|
+|`const struct mg_request_info *`|Pointer to the requested info, or NULL if an error occurred|
 
 ### Description
 

--- a/docs/api/mg_get_server_ports.md
+++ b/docs/api/mg_get_server_ports.md
@@ -20,7 +20,7 @@
 
 The `mg_get_server_ports()` returns a list with server ports on which the Civetweb server is listening. The ports are returned for a given context and stored with additional information like the SSL and redirection state in a list of structures. The list of structures must be allocated by the calling routine. The size of the structure is also passed to `mg_get_server_ports()`.
 
-The function returns the number of items in the list, or a negative value if an error occured.
+The function returns the number of items in the list, or a negative value if an error occurred.
 
 ### See Also
 

--- a/docs/api/mg_get_user_connection_data.md
+++ b/docs/api/mg_get_user_connection_data.md
@@ -16,7 +16,7 @@
 
 ### Description
 
-The function `mg_get_user_connection_data()` returns the user data associated with a connection. This user data is represented with a pointer which has been prevously registered with a call to [`mg_set_user_connection_data();`](mg_set_user_connection_data.md). With this function it is possible to pass state information between callback functions refering to a specific connection.
+The function `mg_get_user_connection_data()` returns the user data associated with a connection. This user data is represented with a pointer which has been prevously registered with a call to [`mg_set_user_connection_data();`](mg_set_user_connection_data.md). With this function it is possible to pass state information between callback functions referring to a specific connection.
 
 ### See Also
 

--- a/docs/api/mg_get_valid_option_names.md
+++ b/docs/api/mg_get_valid_option_names.md
@@ -14,7 +14,7 @@
 
 ### Description
 
-The function `mg_get_valid_option_names()` is depricated. Use [`mg_get_valid_options()`](mg_get_valid_options.md) instead.
+The function `mg_get_valid_option_names()` is deprecated. Use [`mg_get_valid_options()`](mg_get_valid_options.md) instead.
 
 This function returns an array with option/value pairs describing the valid configuration options for Civetweb. En element value of NULL signals the end of the list.
 

--- a/docs/api/mg_get_var2.md
+++ b/docs/api/mg_get_var2.md
@@ -21,7 +21,7 @@
 
 ### Description
 
-The function `mg_get_var2()` can be used to return the contents of a variable passed to the server as either POST data, or in the URI in a GET call. The function is somilar to [`mg_get_var()`](mg_get_var.md) but the difference is that `mg_get_var2()` can be used if the same variable is present multiple times in the data. The `occurence` parameter is used to identify which instance of the variable must be returned where **`0`** is used for the first variable with the specified name, **`1`** for the second and so on.
+The function `mg_get_var2()` can be used to return the contents of a variable passed to the server as either POST data, or in the URI in a GET call. The function is somilar to [`mg_get_var()`](mg_get_var.md) but the difference is that `mg_get_var2()` can be used if the same variable is present multiple times in the data. The `occurrence` parameter is used to identify which instance of the variable must be returned where **`0`** is used for the first variable with the specified name, **`1`** for the second and so on.
 
 The function returns the length of the variable content in the return buffer, **`-1`** if a variable with the specified name could not be found and **`-2`** if the pointer to the result buffer is NULL, the size of the result buffer is zero or when the result buffer is too small to contain the variable content and terminating NUL.
 

--- a/docs/api/mg_handle_form_request.md
+++ b/docs/api/mg_handle_form_request.md
@@ -17,7 +17,7 @@
 
 ### Description
 
-The function `mg_handle_form_request()` processes form data on a connection. The function uses callback functions for the heavy lifting which are passed to the function as fields in a [`struct mg_form_data_handler`](mg_form_data_handler.md) structure. The number of processed fields is returned by the function, or a negative value when an error occured. I nthe situation where some fields are processed successfully (for example file downloads) and an error occurs later in the form processing, the function still returns a negative value. It is the responsibility of the calling party to do the necessary cleanup. The calling party should also do the cleanup of any files which are created, but not required anymore later.
+The function `mg_handle_form_request()` processes form data on a connection. The function uses callback functions for the heavy lifting which are passed to the function as fields in a [`struct mg_form_data_handler`](mg_form_data_handler.md) structure. The number of processed fields is returned by the function, or a negative value when an error occurred. I nthe situation where some fields are processed successfully (for example file downloads) and an error occurs later in the form processing, the function still returns a negative value. It is the responsibility of the calling party to do the necessary cleanup. The calling party should also do the cleanup of any files which are created, but not required anymore later.
 
 ### See Also
 

--- a/docs/api/mg_set_websocket_handler.md
+++ b/docs/api/mg_set_websocket_handler.md
@@ -25,6 +25,6 @@
 
 ### Description
 
-The function `mg_set_websocket_handler()` connects callback functions to a websocket URI. The callback functions are called when a state change is detected on the URI like an incomming connection or data received from a remote peer.
+The function `mg_set_websocket_handler()` connects callback functions to a websocket URI. The callback functions are called when a state change is detected on the URI like an incoming connection or data received from a remote peer.
 
 ### See Also

--- a/docs/api/mg_start_thread.md
+++ b/docs/api/mg_start_thread.md
@@ -19,7 +19,7 @@
 
 ### Description
 
-The function `mg_start_thread()` is a convenience function to create a detached thread. The function returns **0** when successful and another value if an error occured. A pointer to user supplied data can be passed which is then passed further on to the thread function as parameter.
+The function `mg_start_thread()` is a convenience function to create a detached thread. The function returns **0** when successful and another value if an error occurred. A pointer to user supplied data can be passed which is then passed further on to the thread function as parameter.
 
 ### See Also
 

--- a/docs/api/mg_websocket_client_write.md
+++ b/docs/api/mg_websocket_client_write.md
@@ -21,7 +21,7 @@
 
 The function `mg_websocket_client_write()` sends data to a websocket server wrapped in a masked websocket frame. The function issues calls to [`mg_lock_connection()`](mg_lock_connection.md) and [`mg_unlock_connection()`](mg_unlock_connection.md) to ensure that the transmission is not interrupted. Interruption can happen the the application is proactively communicating and responding to a request simultaneously. This function is available only, if Civetweb is compiled with the option `-DUSE_WEBSOCKET`.
 
-The return value is the number of bytes written on success, **0** when the connection has been closed and **-1** if an error occured.
+The return value is the number of bytes written on success, **0** when the connection has been closed and **-1** if an error occurred.
 
 ### See Also
 

--- a/examples/_obsolete/ws_server/ws_server.c
+++ b/examples/_obsolete/ws_server/ws_server.c
@@ -214,7 +214,7 @@ static int websocket_data_handler(struct mg_connection *conn, int flags,
             /* If client initiated close, respond with close message in acknowlegement */
             if (!ws_conn[wsd].closing) {
                 mg_websocket_write(conn, WEBSOCKET_OPCODE_CONNECTION_CLOSE, data, data_len);
-                ws_conn[wsd].closing = 1; /* we should not send addional messages when close requested/acknowledged */
+                ws_conn[wsd].closing = 1; /* we should not send additional messages when close requested/acknowledged */
             }
             return 0; /* time to close the connection */
             break;

--- a/examples/embedded_c/embedded_c.c
+++ b/examples/embedded_c/embedded_c.c
@@ -765,7 +765,7 @@ WebSocketCloseHandler(const struct mg_connection *conn, void *cbdata)
 	mg_unlock_context(ctx);
 
 	fprintf(stdout,
-	        "Client droped from the set of webserver connections\r\n\r\n");
+	        "Client dropped from the set of webserver connections\r\n\r\n");
 }
 
 
@@ -978,10 +978,10 @@ main(int argc, char *argv[])
 	mg_set_request_handler(ctx, "/B/A$", BXHandler, (void *)1);
 	mg_set_request_handler(ctx, "/B/B$", BXHandler, (void *)2);
 
-	/* Add handler for all files with .foo extention */
+	/* Add handler for all files with .foo extension */
 	mg_set_request_handler(ctx, "**.foo$", FooHandler, 0);
 
-	/* Add handler for /close extention */
+	/* Add handler for /close extension */
 	mg_set_request_handler(ctx, "/close", CloseHandler, 0);
 
 	/* Add handler for /form  (serve a file outside the document root) */

--- a/include/CivetServer.h
+++ b/include/CivetServer.h
@@ -372,7 +372,7 @@ class CIVETWEB_API CivetServer
 	 * getHeader(struct mg_connection *conn, const std::string &headerName)
 	 * @param conn - the connection information
 	 * @param headerName - header name to get the value from
-	 * @returns a char array whcih contains the header value as string
+	 * @returns a char array which contains the header value as string
 	*/
 	static const char *getHeader(struct mg_connection *conn,
 	                             const std::string &headerName);
@@ -380,8 +380,8 @@ class CIVETWEB_API CivetServer
 	/**
 	 * getParam(struct mg_connection *conn, const char *, std::string &, size_t)
 	 *
-	 * Returns a query paramter contained in the supplied buffer.  The
-	 * occurance value is a zero-based index of a particular key name.  This
+	 * Returns a query which contained in the supplied buffer.  The
+	 * occurrence value is a zero-based index of a particular key name.  This
 	 * should not be confused with the index over all of the keys.  Note that
 	 *this
 	 * function assumes that parameters are sent as text in http query string
@@ -408,8 +408,8 @@ class CIVETWEB_API CivetServer
 	/**
 	 * getParam(const std::string &, const char *, std::string &, size_t)
 	 *
-	 * Returns a query paramter contained in the supplied buffer.  The
-	 * occurance value is a zero-based index of a particular key name.  This
+	 * Returns a query parameter contained in the supplied buffer.  The
+	 * occurrence value is a zero-based index of a particular key name.  This
 	 * should not be confused with the index over all of the keys.
 	 *
 	 * @param data - the query string (text)
@@ -431,8 +431,8 @@ class CIVETWEB_API CivetServer
 	/**
 	 * getParam(const char *, size_t, const char *, std::string &, size_t)
 	 *
-	 * Returns a query paramter contained in the supplied buffer.  The
-	 * occurance value is a zero-based index of a particular key name.  This
+	 * Returns a query parameter contained in the supplied buffer.  The
+	 * occurrence value is a zero-based index of a particular key name.  This
 	 * should not be confused with the index over all of the keys.
 	 *
 	 * @param data the - query string (text)
@@ -457,7 +457,7 @@ class CIVETWEB_API CivetServer
 	 * This uses string to store post data to handle big posts.
 	 *
 	 * @param conn - connection from which post data will be read
-	 * @return Post data (empty if not avaliable).
+	 * @return Post data (empty if not available).
 	 */
 	static std::string getPostData(struct mg_connection *conn);
 
@@ -575,7 +575,7 @@ class CIVETWEB_API CivetServer
 	/**
 	 * requestHandler(struct mg_connection *, void *cbdata)
 	 *
-	 * Handles the incomming request.
+	 * Handles the incoming request.
 	 *
 	 * @param conn - the connection information
 	 * @param cbdata - pointer to the CivetHandler instance.

--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -1048,7 +1048,7 @@ CIVETWEB_API int mg_get_cookie(const char *cookie,
 /* Download data from the remote web server.
      host: host name to connect to, e.g. "foo.com", or "10.12.40.1".
      port: port number, e.g. 80.
-     use_ssl: wether to use SSL connection.
+     use_ssl: whether to use SSL connection.
      error_buffer, error_buffer_size: error message placeholder.
      request_fmt,...: HTTP request.
    Return:

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -114,7 +114,7 @@ mg_static_assert(sizeof(void *) >= sizeof(int), "data type size check");
  * Symbian is no longer maintained since 2014-01-01.
  * Recent versions of CivetWeb are no longer tested for Symbian.
  * It makes no sense, to support an abandoned operating system.
- * All remaining "#ifdef __SYMBIAN__" cases will be droped from
+ * All remaining "#ifdef __SYMBIAN__" cases will be dropped from
  * the code sooner or later.
  */
 #pragma message                                                                \
@@ -3766,7 +3766,7 @@ get_header(const struct mg_header *hdr, int num_hdr, const char *name)
 
 #if defined(USE_WEBSOCKET)
 /* Retrieve requested HTTP header multiple values, and return the number of
- * found occurences */
+ * found occurrences */
 static int
 get_req_headers(const struct mg_request_info *ri,
                 const char *name,
@@ -6057,7 +6057,7 @@ pull_inner(FILE *fp,
 			/* EAGAIN/EWOULDBLOCK:
 			 * standard case if called from close_socket_gracefully
 			 * => should return -1 */
-			/* or timeout occured
+			/* or timeout occurred
 			 * => the code must stay in the while loop */
 
 			/* EINTR can be generated on a socket with a timeout set even
@@ -6071,7 +6071,7 @@ pull_inner(FILE *fp,
 #endif
 	}
 
-	/* Timeout occured, but no data available. */
+	/* Timeout occurred, but no data available. */
 	return -1;
 }
 
@@ -15316,7 +15316,7 @@ close_connection(struct mg_connection *conn)
 
 #ifndef NO_SSL
 	if (conn->ssl != NULL) {
-		/* Run SSL_shutdown twice to ensure completly close SSL connection
+		/* Run SSL_shutdown twice to ensure completely close SSL connection
 		 */
 		SSL_shutdown(conn->ssl);
 		SSL_free(conn->ssl);
@@ -16161,7 +16161,7 @@ mg_download(const char *host,
 		}
 	}
 
-	/* if an error occured, close the connection */
+	/* if an error occurred, close the connection */
 	if ((ebuf[0] != '\0') && (conn != NULL)) {
 		mg_close_connection(conn);
 		conn = NULL;

--- a/src/mod_lua.inl
+++ b/src/mod_lua.inl
@@ -13,7 +13,7 @@ mmap(void *addr, int64_t len, int prot, int flags, int fd, int offset)
 	 * Currently it is sufficient, but there are a lot of unused parameters.
 	 * Better use a function "mg_map" which only has the required parameters,
 	 * and implement it using mmap in Linux and CreateFileMapping in Windows.
-	 * Noone should expect a full mmap for Windows here.
+	 * No one should expect a full mmap for Windows here.
 	 */
 	HANDLE fh = (HANDLE)_get_osfhandle(fd);
 	HANDLE mh = CreateFileMapping(fh, 0, PAGE_READONLY, 0, 0, 0);
@@ -639,7 +639,7 @@ lsp_include(lua_State *L)
 
 			if (handle_lsp_request(conn, file_name_path, &file, L)) {
 				/* handle_lsp_request returned an error code, meaning an error
-				* occured in the included page and mg.onerror returned non-zero.
+				* occurred in the included page and mg.onerror returned non-zero.
 				* Stop processing.
 				*/
 

--- a/test/html_esc.lua
+++ b/test/html_esc.lua
@@ -33,7 +33,7 @@ htmlEscape = {    "&#x263a;", "&#x263b;", "&#x2665;", "&#x2666;", "&#x2663;", "&
 };
 htmlEscape[0] = "&middot;" -- in this table, we use a 8 bit character set, where every has a different graphical representation
 
--- the conversion table should work as a convertion function for strings as well
+-- the conversion table should work as a conversion function for strings as well
 setmetatable(htmlEscape, {__call = function (tab,str) return string.gsub(str, ".", function (c) return tab[c:byte()] end) end})
 
 

--- a/unittest/public_func.c
+++ b/unittest/public_func.c
@@ -356,7 +356,7 @@ START_TEST(test_mg_get_var)
 	ck_assert_int_eq(ret, 10);
 	ck_assert_str_eq("this is it", buf);
 
-	/* longer value in the middle of a longer string - seccond occurance of key
+	/* longer value in the middle of a longer string - seccond occurrence of key
 	 */
 	memset(buf, 77, sizeof(buf));
 	ret =

--- a/unittest/public_server.c
+++ b/unittest/public_server.c
@@ -2938,7 +2938,7 @@ START_TEST(test_handle_form)
 	send_chunk_string(client_conn, "\r\n");
 
 	/* send some kilobyte of data */
-	/* sending megabytes to localhost does not allways work in CI test
+	/* sending megabytes to localhost does not always work in CI test
 	 * environments (depending on the network stack) */
 	body_sent = 0;
 	do {
@@ -3511,7 +3511,7 @@ START_TEST(test_error_handling)
 	    mg_connect_client("127.0.0.1", 8080, 0, client_err, sizeof(client_err));
 	ck_assert(client_conn == NULL);
 
-	/* Error message detail may vary - it may not be empty ans should contain
+	/* Error message detail may vary - it may not be empty and should contain
 	 * some information "connect" failed */
 	ck_assert_str_ne(client_err, "");
 	ck_assert(strstr(client_err, "connect"));


### PR DESCRIPTION
Fixed misspellings found by [codespell](https://github.com/lucasdemarchi/codespell).