### PR TITLE
Added replacement for timegm where _mkgmtime can be missing.

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -451,7 +451,53 @@ typedef long off_t;
 #define funlockfile(x) (LeaveCriticalSection(&global_log_file_lock))
 #define sleep(x) (Sleep((x)*1000))
 #define rmdir(x) (_rmdir(x))
+#if defined(_WIN64)
 #define timegm(x) (_mkgmtime(x))
+#else
+static inline int is_leap(int y) {
+  return (y % 4 == 0 && y % 100 != 0) || y % 400 == 0;
+}
+
+static inline int count_leap(int y) {
+  return (y - 1969) / 4 - (y - 1901) / 100 + (y - 1601) / 400;
+}
+
+time_t timegm(struct tm *tm);
+time_t timegm(struct tm *tm) {
+  static const unsigned short ydays[] = {
+    0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365
+  };
+  int year = tm->tm_year + 1900;
+  int mon = tm->tm_mon;
+  int mday = tm->tm_mday - 1;
+  int hour = tm->tm_hour;
+  int min = tm->tm_min;
+  int sec = tm->tm_sec;
+
+  if (year < 1970
+      || mon < 0 || mon > 11
+      || mday < 0 || (mday >= ydays[mon + 1] - ydays[mon]
+                      + (mon == 1 && is_leap(year) ? 1 : 0))
+      || hour < 0 || hour > 23
+      || min < 0 || min > 59
+      || sec < 0 || sec > 60)
+  return -1;
+
+  time_t res = year - 1970;
+  res *= 365;
+  res += mday;
+  res += ydays[mon] + (mon > 1 && is_leap(year) ? 1 : 0);
+  res += count_leap(year);
+
+  res *= 24;
+  res += hour;
+  res *= 60;
+  res += min;
+  res *= 60;
+  res += sec;
+  return res;
+}
+#endif /* !_WIN64 */
 
 #if !defined(fileno)
 #define fileno(x) (_fileno(x))


### PR DESCRIPTION
Please consider to pull this as a solution for the part of issue https://github.com/civetweb/civetweb/issues/278 related to missing _mkgmtime in msvcrt.dll on 32-bits machines.