### PR TITLE
Fixing configuration of ports for IPv4/IPv6 dual host sockets

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -13810,7 +13810,7 @@ set_ports_option(struct mg_context *phys_ctx)
 
 		if (ip_version > 4) {
 #if defined(USE_IPV6)
-			if (ip_version == 6) {
+			if (ip_version > 6) {
 				if (so.lsa.sa.sa_family == AF_INET6
 				    && setsockopt(so.sock,
 				                  IPPROTO_IPV6,


### PR DESCRIPTION
When checking for configuring a socket, if the port option indicates that
a dual host socket should be used (single socket to receive traffic from
IPv4 and IPv6 addresses, e.g., `+80`), the IP version returned is 10. To
signal that a socket should be used by both versions, the IPV6_ONLY socket
option should be set to 0. Prior to this commit, `set_ports_option` looked
for an IP version equal to 6 to set the option to zero, but should be
looking for a version of 10.