### PR TITLE
Fix warning about implicit function declaration in CivetWeb

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -45,7 +45,7 @@
 #endif
 #else
 #if defined(__GNUC__) && !defined(_GNU_SOURCE)
-#define _GNU_SOURCE /* for setgroups() */
+#define _GNU_SOURCE /* for setgroups(), pthread_setname_np() */
 #endif
 #if defined(__linux__) && !defined(_XOPEN_SOURCE)
 #define _XOPEN_SOURCE 600 /* For flockfile() on Linux */
@@ -2941,7 +2941,7 @@ mg_set_thread_name(const char *name)
 #elif defined(__MINGW32__)
 /* No option known to set thread name for MinGW */
 #endif
-#elif defined(__GLIBC__)                                                       \
+#elif defined(_GNU_SOURCE) && defined(__GLIBC__)                                                       \
     && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12)))
 	/* pthread_setname_np first appeared in glibc in version 2.12*/
 	(void)pthread_setname_np(pthread_self(), threadName);


### PR DESCRIPTION
Using pthread_setname_np requires a #define _GNU_SOURCE before including
pthread.h, or it will cause warnings about implicit function
declaration:

net/http/civetweb/civetweb.c:2701:8: warning:
 implicit declaration of function 'pthread_setname_np' is invalid in C99
         (void)pthread_setname_np(pthread_self(), threadName);
               ^