### PR TITLE
Wait for ready socket using poll instead of select

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -6155,33 +6155,17 @@ push_inner(struct mg_context *ctx,
 			 * Maybe it helps, maybe not. */
 			mg_sleep(5);
 		} else {
-			/* For sockets, wait for the socket using select */
-			fd_set wfds;
-			struct timeval tv;
-			int sret;
+			/* For sockets, wait for the socket using poll */
+			struct pollfd pfd[1];
+			int pollres;
 
-#if defined(__GNUC__) || defined(__MINGW32__)
-/* GCC seems to have a flaw with it's own socket macros:
- * http://www.linuxquestions.org/questions/programming-9/impossible-to-use-gcc-with-wconversion-and-standard-socket-macros-841935/
- */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsign-conversion"
-#endif
-
-			FD_ZERO(&wfds);
-			FD_SET(sock, &wfds);
-			tv.tv_sec = (time_t)(ms_wait / 1000);
-			tv.tv_usec = (long)((ms_wait % 1000) * 1000);
-
-			sret = select((int)sock + 1, NULL, &wfds, NULL, &tv);
-
-#if defined(__GNUC__) || defined(__MINGW32__)
-#pragma GCC diagnostic pop
-#endif
-
-			if (sret > 0) {
-				/* We got ready to write. Don't check the timeout
-				 * but directly go back to write again. */
+			pfd[0].fd = sock;
+			pfd[0].events = POLLOUT;
+			pollres = mg_poll(pfd, 1, (int)(ms_wait), &(ctx->stop_flag));
+			if (ctx->stop_flag) {
+				return -2;
+			}
+			if (pollres > 0) {
 				continue;
 			}
 		}


### PR DESCRIPTION
Select does not work with descriptor numbers bigger than 1024.
It cause application fail, when get such descriptor number.
I suggest to use poll instead of select.