### PR TITLE
Function abort_process is not defined unless we are using timers.

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -11100,7 +11100,9 @@ done:
 	mg_free(blk.buf);
 
 	if (pid != (pid_t)-1) {
+#if defined(USE_TIMERS)
 		abort_process((void *)pid);
+#endif
 	}
 	if (fdin[0] != -1) {
 		close(fdin[0]);


### PR DESCRIPTION
Function abort_process is not defined unless USE_TIMERS is defined, and so the previous version would not compile.