### PR TITLE
build: warning fixes for test executables

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1536,8 +1536,13 @@ struct dlg_header_param {
 };
 
 static struct dlg_header_param
-GetDlgHeader(unsigned pWidth)
+GetDlgHeader(const short width)
 {
+#if defined(_MSC_VER)
+/* disable MSVC warning C4204 (non-constant used to initialize structure) */
+#pragma warning(push)
+#pragma warning(disable:4204)
+#endif /* if defined(_MSC_VER) */
 	struct dlg_header_param dialog_header = {{WS_CAPTION | WS_POPUP | WS_SYSMENU
 	                                              | WS_VISIBLE | DS_SETFONT
 	                                              | WS_DLGFRAME,
@@ -1545,13 +1550,16 @@ GetDlgHeader(unsigned pWidth)
 	                                          0,
 	                                          200,
 	                                          200,
-	                                          pWidth,
+	                                          width,
 	                                          0},
 	                                         0,
 	                                         0,
 	                                         L"",
 	                                         8,
 	                                         L"Tahoma"};
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif /* if defined(_MSC_VER) */
 	return dialog_header;
 }
 

--- a/unittest/public_server.c
+++ b/unittest/public_server.c
@@ -899,7 +899,7 @@ request_test_handler2(struct mg_connection *conn, void *cbdata)
 	const char *chunk_data = "123456789A123456789B123456789C";
 	const struct mg_request_info *ri;
 	struct mg_context *ctx;
-	void *ud, *cud;
+	void *ud;
 
 	ctx = mg_get_context(conn);
 	ud = mg_get_user_data(ctx);


### PR DESCRIPTION
This patch contains additional warning fixes for Microsoft Visual Studio
2015 without any warnings.  Specifically, this patch addresses warnings
generated by the test executables.

Signed-off-by: Keith Holman <keith.holman@windriver.com>