### PR TITLE
undefine macro before redefining

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -86,6 +86,7 @@
 
 #include "civetweb.h"
 
+#undef printf
 #define printf                                                                 \
 	DO_NOT_USE_THIS_FUNCTION__USE_fprintf /* Required for unit testing */
 


### PR DESCRIPTION
Fixes
src/main.c:89:9: error: 'printf' macro redefined [-Werror,-Wmacro-redefined]

Signed-off-by: Khem Raj <raj.khem@gmail.com>