### PR TITLE
Fix - use pthread_setname_np for OS X with proper arguemnts

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -2976,7 +2976,12 @@ mg_set_thread_name(const char *name)
 #elif defined(_GNU_SOURCE) && defined(__GLIBC__)                               \
     && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12)))
 	/* pthread_setname_np first appeared in glibc in version 2.12*/
+#if defined(__MACH__)
+	/* OS X only current thread name can be changed */
+	(void)pthread_setname_np(threadName);
+#else
 	(void)pthread_setname_np(pthread_self(), threadName);
+#endif
 #elif defined(__linux__)
 	/* on linux we can use the old prctl function */
 	(void)prctl(PR_SET_NAME, threadName, 0, 0, 0);


### PR DESCRIPTION
Only name of current thread can be changed on Mac