### PR TITLE
Add support for clientside SNI

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -1388,6 +1388,7 @@ struct mg_client_options {
 	int port;
 	const char *client_cert;
 	const char *server_cert;
+	const char *host_name;
 	/* TODO: add more data */
 };
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -1732,6 +1732,7 @@ typedef struct SSL_CTX SSL_CTX;
 #include <openssl/opensslv.h>
 #include <openssl/pem.h>
 #include <openssl/ssl.h>
+#include <openssl/tls1.h>
 #include <openssl/x509.h>
 
 #if defined(WOLFSSL_VERSION)
@@ -15015,7 +15016,8 @@ static int
 sslize(struct mg_connection *conn,
        SSL_CTX *s,
        int (*func)(SSL *),
-       volatile int *stop_server)
+       volatile int *stop_server,
+	 const struct mg_client_options *client_options)
 {
 	int ret, err;
 	int short_trust;
@@ -15054,6 +15056,12 @@ sslize(struct mg_connection *conn,
 		ERR_remove_state(0);
 #endif
 		return 0;
+	}
+
+	if (client_options) {
+		if (client_options->host_name) {
+			SSL_set_tlsext_host_name(conn->ssl, client_options->host_name);
+		}
 	}
 
 	/* SSL functions may fail and require to be called again:
@@ -16546,7 +16554,8 @@ mg_connect_client_impl(const struct mg_client_options *client_options,
 		if (!sslize(conn,
 		            conn->client_ssl_ctx,
 		            SSL_connect,
-		            &(conn->phys_ctx->stop_flag))) {
+		            &(conn->phys_ctx->stop_flag),
+					client_options)) {
 			mg_snprintf(NULL,
 			            NULL, /* No truncation check for ebuf */
 			            ebuf,
@@ -17834,7 +17843,8 @@ worker_thread_run(struct worker_thread_args *thread_args)
 			if (sslize(conn,
 			           conn->dom_ctx->ssl_ctx,
 			           SSL_accept,
-			           &(conn->phys_ctx->stop_flag))) {
+			           &(conn->phys_ctx->stop_flag),
+					   NULL)) {
 				/* conn->dom_ctx is set in get_request */
 
 				/* Get SSL client certificate information (if set) */


### PR DESCRIPTION
`SSL_set_tlsext_host_name` must be called after context creation and before `SSL_connect`.
Therefore it required me to push the client options to `sslize`.

You can test this by connecting to any website running behind Cloudflare. Without setting the hostname the SSL connection will fail.
