### PR TITLE
GCC warning -Wdate-time appeared first with gcc4.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,6 @@ if (HAVE_NO_RESERVED_ID_MACROS)
 add_c_compiler_flag(-Wno-reserved-id-macros) # for system headers
 endif (HAVE_NO_RESERVED_ID_MACROS)
 add_c_compiler_flag(-Wno-format-nonliteral) # printf(myFormatStringVar, ...)
-add_c_compiler_flag(-Wno-date-time) # using __DATE__ once
 add_c_compiler_flag(-Wno-cast-qual) # const cast
 add_c_compiler_flag(/Wd4820) # padding
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -19046,9 +19046,11 @@ mg_get_system_info_impl(char *buffer, int buflen)
 	/* Build date */
 	{
 #if defined(GCC_DIAGNOSTIC)
+#if GCC_VERSION >= 50000
 #pragma GCC diagnostic push
-/* Disable bogus compiler warning -Wdate-time */
+/* Disable bogus compiler warning -Wdate-time, appeared in gcc5 */
 #pragma GCC diagnostic ignored "-Wdate-time"
+#endif
 #endif
 		mg_snprintf(NULL,
 		            NULL,
@@ -19059,7 +19061,9 @@ mg_get_system_info_impl(char *buffer, int buflen)
 		            eol);
 
 #if defined(GCC_DIAGNOSTIC)
+#if GCC_VERSION >= 50000
 #pragma GCC diagnostic pop
+#endif
 #endif
 
 		system_info_length += (int)strlen(block);

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -19046,7 +19046,7 @@ mg_get_system_info_impl(char *buffer, int buflen)
 	/* Build date */
 	{
 #if defined(GCC_DIAGNOSTIC)
-#if GCC_VERSION >= 50000
+#if GCC_VERSION >= 40900
 #pragma GCC diagnostic push
 /* Disable bogus compiler warning -Wdate-time, appeared in gcc5 */
 #pragma GCC diagnostic ignored "-Wdate-time"
@@ -19061,7 +19061,7 @@ mg_get_system_info_impl(char *buffer, int buflen)
 		            eol);
 
 #if defined(GCC_DIAGNOSTIC)
-#if GCC_VERSION >= 50000
+#if GCC_VERSION >= 40900
 #pragma GCC diagnostic pop
 #endif
 #endif


### PR DESCRIPTION
Do not try do disable it for gcc 4.8, which is still very popular