### PR TITLE
Enable -fPIC when compiling library objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,6 +332,8 @@ distclean: clean
 	$(RMF) $(CPROG) lib$(CPROG).so lib$(CPROG).a *.dmg *.msi *.exe lib$(CPROG).dll lib$(CPROG).dll.a
 	$(RMF) $(UNIT_TEST_PROG)
 
+$(LIB_OBJECTS): CFLAGS += -fPIC
+
 lib$(CPROG).a: CFLAGS += -fPIC
 lib$(CPROG).a: $(LIB_OBJECTS)
 	@$(RMF) $@


### PR DESCRIPTION
The -FPIC flag is used when linking the library, but without -fPIC when compiling civetweb.o, libcivetweb.so will fail to link.

Signed-off-by: John Faith <jfaith@impinj.com>