### PR TITLE
fixed memory leak in get_request when fetching the remote host

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -16939,6 +16939,9 @@ get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 	/* Message is a valid request */
 
 	/* Is there a "host" ? */
+	if (conn->host!=NULL) {
+		mg_free((void *)conn->host);
+	}
 	conn->host = alloc_get_host(conn);
 	if (!conn->host) {
 		mg_snprintf(conn,


### PR DESCRIPTION
There is a memory leak in the get_request function when it calls the alloc_get_host function. The conn->host can contain a valid/existing hostname. This change makes sure that it is free'ed if it already has been set for a connection. 

