### PR TITLE
Fix #686 CivetServer::getPostData valgrind UninitCondition

### DIFF
--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -582,9 +582,7 @@ CivetServer::getPostData(struct mg_connection *conn)
 	char buf[2048];
 	int r = mg_read(conn, buf, sizeof(buf));
 	while (r > 0) {
-		std::string p = std::string(buf);
-		p.resize(r);
-		postdata += p;
+		postdata += std::string(buf, r);
 		r = mg_read(conn, buf, sizeof(buf));
 	}
 	mg_unlock_connection(conn);


### PR DESCRIPTION
Fixes a valgrind issue by limiting the constructed string to the number of bytes read