### PR TITLE
fix relative url in directory listing

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -9083,15 +9083,14 @@ print_dir_entry(struct de *de)
 	}
 	mg_url_encode(de->file_name, href, hrefsize);
 	mg_printf(de->conn,
-	          "<tr><td><a href=\"%s%s%s\">%s%s</a></td>"
-	          "<td>&nbsp;%s</td><td>&nbsp;&nbsp;%s</td></tr>\n",
-	          de->conn->request_info.local_uri,
-	          href,
-	          de->file.is_directory ? "/" : "",
-	          de->file_name,
-	          de->file.is_directory ? "/" : "",
-	          mod,
-	          size);
+              "<tr><td><a href=\"%s%s\">%s%s</a></td>"
+              "<td>&nbsp;%s</td><td>&nbsp;&nbsp;%s</td></tr>\n",
+              href,
+              de->file.is_directory ? "/" : "",
+              de->file_name,
+              de->file.is_directory ? "/" : "",
+              mod,
+              size);
 	mg_free(href);
 	return 0;
 }
@@ -9373,13 +9372,12 @@ handle_directory_request(struct mg_connection *conn, const char *dir)
 
 	/* Print first entry - link to a parent directory */
 	mg_printf(conn,
-	          "<tr><td><a href=\"%s%s\">%s</a></td>"
-	          "<td>&nbsp;%s</td><td>&nbsp;&nbsp;%s</td></tr>\n",
-	          conn->request_info.local_uri,
-	          "..",
-	          "Parent directory",
-	          "-",
-	          "-");
+              "<tr><td><a href=\"%s\">%s</a></td>"
+              "<td>&nbsp;%s</td><td>&nbsp;&nbsp;%s</td></tr>\n",
+              "..",
+              "Parent directory",
+              "-",
+              "-");
 
 	/* Sort and print directory entries */
 	if (data.entries != NULL) {


### PR DESCRIPTION
If civetweb is used behind a reverse proxy (for example, using Apache as a Reverse Proxy with mod_proxy), the listing directory reports wrong file/dir urls.

Example:

I have a civetweb server that answers internally at: `http://127.0.0.1:8080`

Apache configuration:
```
<VirtualHost *:80>
    ProxyPreserveHost On

    ProxyPass /example http://127.0.0.1:8080/
    ProxyPassReverse /example http://127.0.0.1:8080/
</VirtualHost>
```

In my browser I can call
`http://127.0.0.1/example/`
internally I am redirected to
`http://127.0.0.1:8080`

In this case, `request_info.local_uri` is equal to `/` (because it's the proxy that calls civetweb internally).
Suppose the root folder contains `test.txt `
if `request_info.local_uri` is placed in front of the links, I will get the link `/test.txt` which resolves into `http://127.0.0.1/test.txt`
I want the link `test.txt` (relative), which resolves into `http://127.0.0.1/example/test.txt`

With this change, relative urls are used and the links on drectory listing are correct.