### PR TITLE
Export CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -486,6 +486,32 @@ if (CIVETWEB_BUILD_TESTING)
   add_subdirectory(unittest)
 endif()
 
+# cmake config file
+
+include(CMakePackageConfigHelpers)
+
+install(
+  EXPORT ${PROJECT_NAME}-targets
+  NAMESPACE ${PROJECT_NAME}::
+  FILE ${PROJECT_NAME}-targets.cmake
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+  COMPONENT civetweb-cmake-config
+)
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake.in"
+  ${PROJECT_NAME}-config.cmake
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+)
+
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+  COMPONENT civetweb-cmake-config
+)
+
 # Set up CPack
 include(InstallRequiredSystemLibraries)
 set(CPACK_PACKAGE_VENDOR "civetweb Contributors")

--- a/cmake/civetweb-config.cmake.in
+++ b/cmake/civetweb-config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+include(CMakeFindDependencyMacro)
+
+set_and_check(civetweb_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+
+include("${CMAKE_CURRENT_LIST_DIR}/civetweb-targets.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ endif()
 add_library(civetweb-c-library ${LIB_TYPE} civetweb.c)
 set_target_properties(civetweb-c-library PROPERTIES
   OUTPUT_NAME "civetweb"
+  EXPORT_NAME "civetweb"
   VERSION ${CIVETWEB_VERSION}
   SOVERSION ${CIVETWEB_VERSION}
 )
@@ -14,13 +15,15 @@ if (BUILD_SHARED_LIBS)
 endif()
 target_include_directories(
   civetweb-c-library PUBLIC
-  ${PROJECT_SOURCE_DIR}/include)
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 install(
   TARGETS civetweb-c-library
+  EXPORT ${PROJECT_NAME}-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  COMPONENT civetweb-c-library)
+  COMPONENT civetweb-c-library
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(FILES
   ${PROJECT_SOURCE_DIR}/include/civetweb.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -247,11 +250,13 @@ endif()
 if (CIVETWEB_ENABLE_SERVER_EXECUTABLE)
     add_executable(civetweb-c-executable main.c)
     set_target_properties(civetweb-c-executable PROPERTIES
+        EXPORT_NAME "server"
         OUTPUT_NAME "civetweb"
     )
     if (CIVETWEB_INSTALL_EXECUTABLE)
         install(
             TARGETS civetweb-c-executable
+            EXPORT ${PROJECT_NAME}-targets
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -259,7 +264,7 @@ if (CIVETWEB_ENABLE_SERVER_EXECUTABLE)
     endif()
     target_include_directories(
         civetweb-c-executable PUBLIC
-        ${PROJECT_SOURCE_DIR}/include)
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
     target_link_libraries(civetweb-c-executable civetweb-c-library)
     if (LIBRT_FOUND)
         target_link_libraries(civetweb-c-executable LIBRT::LIBRT)
@@ -275,19 +280,22 @@ if (CIVETWEB_ENABLE_LUA)
   )
   target_include_directories(
     lua-library PUBLIC
-    ${PROJECT_SOURCE_DIR}/src/third_party/lua-5.2.4)
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/third_party/lua-5.2.4>)
   install(
     TARGETS lua-library
+    EXPORT ${PROJECT_NAME}-targets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    COMPONENT lua-library)
+    COMPONENT lua-library
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()
 
 # The C++ API library
 if (CIVETWEB_ENABLE_CXX)
   add_library(civetweb-cpp ${LIB_TYPE} CivetServer.cpp)
   set_target_properties(civetweb-cpp PROPERTIES
+    EXPORT_NAME "civetweb-cpp"
     OUTPUT_NAME "civetweb-cpp"
     VERSION ${CIVETWEB_VERSION}
     SOVERSION ${CIVETWEB_VERSION}
@@ -300,13 +308,15 @@ if (CIVETWEB_ENABLE_CXX)
 	civetweb-c-library)
   target_include_directories(
     civetweb-cpp PUBLIC
-    ${PROJECT_SOURCE_DIR}/include)
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
   install(
     TARGETS civetweb-cpp
+    EXPORT ${PROJECT_NAME}-targets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    COMPONENT civetweb-cpp)
+    COMPONENT civetweb-cpp
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
   install(FILES
     ${PROJECT_SOURCE_DIR}/include/CivetServer.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}


### PR DESCRIPTION
That patch adds exporting of the CMake targets for later consumption. If replaces the need to write a custom `FindCivetWeb.cmake` and makes instead the project describing itself.

I have not tested it on Windows, yet. But it's a start and better than noting.