### PR TITLE
CPP interface: Added getter for full port information

### DIFF
--- a/include/CivetServer.h
+++ b/include/CivetServer.h
@@ -369,15 +369,25 @@ class CIVETWEB_CXX_API CivetServer
 	std::vector<int> getListeningPorts();
 
 	/**
+	 * getListeningPorts()
+	 *
+	 * Variant of getListeningPorts() returning the full port information
+	 * (protocol, SSL, ...)
+	 *
+	 * @return A vector of ports
+	 */
+	std::vector<struct mg_server_ports> getListeningPortsFull();
+
+	/**
 	 * getCookie(struct mg_connection *conn, const std::string &cookieName,
-	 *std::string &cookieValue)
+	 * std::string &cookieValue)
 	 *
 	 * Puts the cookie value string that matches the cookie name in the
-	 *cookieValue destinaton string.
+	 * cookieValue destination string.
 	 *
 	 * @param conn - the connection information
 	 * @param cookieName - cookie name to get the value from
-	 * @param cookieValue - cookie value is returned using thiis reference
+	 * @param cookieValue - cookie value is returned using this reference
 	 * @returns the size of the cookie value string read.
 	 */
 	static int getCookie(struct mg_connection *conn,

--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -622,22 +622,29 @@ CivetServer::urlEncode(const char *src,
 std::vector<int>
 CivetServer::getListeningPorts()
 {
-	std::vector<int> ports(50);
+	std::vector<struct mg_server_ports> server_ports = getListeningPortsFull();
+
+	std::vector<int> ports(server_ports.size());
+	for (size_t i = 0; i < server_ports.size(); i++) {
+		ports[i] = server_ports[i].port;
+	}
+
+	return ports;
+}
+
+std::vector<struct mg_server_ports>
+CivetServer::getListeningPortsFull()
+{
 	std::vector<struct mg_server_ports> server_ports(50);
 	int size = mg_get_server_ports(context,
 	                               (int)server_ports.size(),
 	                               &server_ports[0]);
 	if (size <= 0) {
-		ports.resize(0);
-		return ports;
+		server_ports.resize(0);
+		return server_ports;
 	}
-	ports.resize(size);
 	server_ports.resize(size);
-	for (int i = 0; i < size; i++) {
-		ports[i] = server_ports[i].port;
-	}
-
-	return ports;
+	return server_ports;
 }
 
 CivetServer::CivetConnection::CivetConnection()


### PR DESCRIPTION
To be able to query port details like SSL.

I am not convinced by the naming though. If you have a better idea than ``getListeningPortsFull()``. I can change it.

**EDIT** By the way, why is the struct called ``mg_server_ports`` and not ``mg_server_port``?