### PR TITLE
modlua.ini: include dlfcn.h

### DIFF
--- a/src/mod_lua.inl
+++ b/src/mod_lua.inl
@@ -2,6 +2,9 @@
  * See https://github.com/civetweb/civetweb/
  */
 
+#if !defined(_WIN32)
+#include <dlfcn.h>
+#endif
 #include "civetweb_lua.h"
 #include "civetweb_private_lua.h"
 


### PR DESCRIPTION
dlfcn.h must be included to be able to use dlopen otherwise build will
fail on:
src/mod_lua.inl:2845:41: error: 'RTLD_LAZY' undeclared (first use in this function)
  lib_handle_uuid = dlopen("libuuid.so", RTLD_LAZY);

Fixes:
 - http://autobuild.buildroot.org/results/7a189f49c5a8b6f7b3d4c57cda5982adc65dbc19

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>