### PR TITLE
partial fix to support Linux Standard Base (LSB)

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -59,6 +59,9 @@
 #if defined(__linux__) && !defined(_XOPEN_SOURCE)
 #define _XOPEN_SOURCE 600 /* For flockfile() on Linux */
 #endif
+#if defined(__LSB_VERSION__)
+#define NEED_TIMEGM
+#endif
 #if !defined(_LARGEFILE_SOURCE)
 #define _LARGEFILE_SOURCE /* For fseeko(), ftello() */
 #endif
@@ -2969,6 +2972,12 @@ event_destroy(void *eventhdl)
 #endif
 
 
+#if defined(__LSB_VERSION__)
+void
+mg_set_thread_name(const char *threadName)
+{
+}
+#else /* !defined(__LSB__) */
 static void
 mg_set_thread_name(const char *name)
 {
@@ -3010,6 +3019,7 @@ mg_set_thread_name(const char *name)
 	(void)prctl(PR_SET_NAME, threadName, 0, 0, 0);
 #endif
 }
+#endif
 #else /* !defined(NO_THREAD_NAME) */
 void
 mg_set_thread_name(const char *threadName)

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -61,6 +61,7 @@
 #endif
 #if defined(__LSB_VERSION__)
 #define NEED_TIMEGM
+#define NO_THREAD_NAME
 #endif
 #if !defined(_LARGEFILE_SOURCE)
 #define _LARGEFILE_SOURCE /* For fseeko(), ftello() */
@@ -2972,12 +2973,6 @@ event_destroy(void *eventhdl)
 #endif
 
 
-#if defined(__LSB_VERSION__)
-void
-mg_set_thread_name(const char *threadName)
-{
-}
-#else /* !defined(__LSB__) */
 static void
 mg_set_thread_name(const char *name)
 {
@@ -3019,7 +3014,6 @@ mg_set_thread_name(const char *name)
 	(void)prctl(PR_SET_NAME, threadName, 0, 0, 0);
 #endif
 }
-#endif
 #else /* !defined(NO_THREAD_NAME) */
 void
 mg_set_thread_name(const char *threadName)


### PR DESCRIPTION
This changeset implements a partial fix for LSB, as described in issue #722. It solves the problem of missing symbols `pthread_setname_np` and `timegm`.