### PR TITLE
Log SSL error also on client connections

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -16455,7 +16455,8 @@ mg_connect_client_impl(const struct mg_client_options *client_options,
 		            NULL, /* No truncation check for ebuf */
 		            ebuf,
 		            ebuf_len,
-		            "SSL_CTX_new error");
+		            "SSL_CTX_new error: %s",
+		            ssl_error());
 		closesocket(sock);
 		mg_free(conn);
 		return NULL;
@@ -16468,7 +16469,8 @@ mg_connect_client_impl(const struct mg_client_options *client_options,
 		            NULL, /* No truncation check for ebuf */
 		            ebuf,
 		            ebuf_len,
-		            "SSL_CTX_new error");
+		            "SSL_CTX_new error: %s",
+			    ssl_error());
 		closesocket(sock);
 		mg_free(conn);
 		return NULL;


### PR DESCRIPTION
Be more verbose about SSL connection error on client side.  This might
help user to figure out his error.