### PR TITLE
Use correct name of file (certificate chain) in error message

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -15556,7 +15556,7 @@ ssl_use_pem_file(struct mg_context *phys_ctx,
 			mg_cry_ctx_internal(phys_ctx,
 			                    "%s: cannot use certificate chain file %s: %s",
 			                    __func__,
-			                    pem,
+			                    chain,
 			                    ssl_error());
 			return 0;
 		}


### PR DESCRIPTION
Use correct file name when printing error message after unsuccessful
call to SSL_CTX_use_certificate_chain_file().

Signed-off-by: Krzysztof Kozlowski <krzk@kernel.org>