### PR TITLE
Documentation: mg_get_context_info.md fixed typo

### DIFF
--- a/docs/api/mg_get_context_info.md
+++ b/docs/api/mg_get_context_info.md
@@ -7,8 +7,8 @@
 | Parameter | Type | Description |
 | :--- | :--- | :--- |
 |**`ctx`**|`struct mg_context *`|The server context handle|
-|**`buffer**|`char *`|A string buffer to store the information|
-|**`buflen**|`int`|Size of the string buffer (including space for a terminating 0)|
+|**`buffer`**|`char *`|A string buffer to store the information|
+|**`buflen`**|`int`|Size of the string buffer (including space for a terminating 0)|
 
 ### Return Value
 


### PR DESCRIPTION
Added missing apostrophes.