### PR TITLE
Add option to disable filesystems support

### DIFF
--- a/examples/embedded_c/embedded_c.c
+++ b/examples/embedded_c/embedded_c.c
@@ -956,8 +956,10 @@ int
 main(int argc, char *argv[])
 {
 	const char *options[] = {
+#if !defined(NO_FILES)
 	    "document_root",
 	    DOCUMENT_ROOT,
+#endif
 	    "listening_ports",
 	    PORT,
 	    "request_timeout_ms",

--- a/examples/embedded_c/embedded_c.c
+++ b/examples/embedded_c/embedded_c.c
@@ -220,6 +220,7 @@ CloseHandler(struct mg_connection *conn, void *cbdata)
 }
 
 
+#if !defined(NO_FILESYSTEMS)
 int
 FileHandler(struct mg_connection *conn, void *cbdata)
 {
@@ -229,6 +230,7 @@ FileHandler(struct mg_connection *conn, void *cbdata)
 	mg_send_file(conn, fileName);
 	return 1;
 }
+#endif /* NO_FILESYSTEMS */
 
 
 #define MD5_STATIC static
@@ -585,6 +587,7 @@ PostResponser(struct mg_connection *conn, void *cbdata)
 }
 
 
+#if !defined(NO_FILESYSTEMS)
 int
 AuthStartHandler(struct mg_connection *conn, void *cbdata)
 {
@@ -653,6 +656,7 @@ AuthStartHandler(struct mg_connection *conn, void *cbdata)
 
 	return 1;
 }
+#endif /* NO_FILESYSTEMS */
 
 
 int
@@ -1048,11 +1052,13 @@ main(int argc, char *argv[])
 	/* Add handler for /close extension */
 	mg_set_request_handler(ctx, "/close", CloseHandler, 0);
 
+#if !defined(NO_FILESYSTEMS)
 	/* Add handler for /form  (serve a file outside the document root) */
 	mg_set_request_handler(ctx,
 	                       "/form",
 	                       FileHandler,
 	                       (void *)"../../test/form.html");
+#endif /* NO_FILESYSTEMS */
 
 	/* Add handler for form data */
 	mg_set_request_handler(ctx,
@@ -1079,8 +1085,10 @@ main(int argc, char *argv[])
 	/* Add HTTP site to open a websocket connection */
 	mg_set_request_handler(ctx, "/websocket", WebSocketStartHandler, 0);
 
+#if !defined(NO_FILESYSTEMS)
 	/* Add HTTP site with auth */
 	mg_set_request_handler(ctx, "/auth", AuthStartHandler, 0);
+#endif /* NO_FILESYSTEMS */
 
 
 #ifdef USE_WEBSOCKET


### PR DESCRIPTION
Hello @bel2125 

This is supposed to serve as the initial PR that will pave the way for the Zephyr RTOS target in civetweb. As you know from your discussion with @PiotrZierhoffer, we would like to start by providing a way of using civetweb without any support for filesystems.

We started by using this with the `embedded_c` sample

Please let us know what you think about it in general and how would you prefer us to approach the various issues.

Some cases that probably need special attention are:
*  We compiled the code with `-DMG_EXTERNAL_FUNCTION_mg_cry_internal_impl` and `-DMG_EXTERNAL_FUNCTION_log_access` because their default implementation depended on files. For test purposes we provided empty functions, but requiring users to do that does not seem like the best approach - maybe adding default empty `__attribute__((weak))` declarations would be acceptable?
* The authorization - for now we just always return a `1` in `check_authorization` - we probably need a better solution for that. Maybe storing all the necessary data in the memory instead of files? We could do that, but your ACK before we start the implementation would be nice.
* The whole `/form` URL in the sample is served from an external file with `mg_send_file`, so by disabling support for files, we lose the form from the sample

The points above definitely require some work, but please let us know if you see some other issues too.