### PR TITLE
Add ARRAY_SIZE definition check

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -439,7 +439,9 @@ _civet_safe_clock_gettime(int clk_id, struct timespec *t)
 /********************************************************************/
 
 /* Helper makros */
+#if !defined(ARRAY_SIZE)
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
+#endif
 
 /* Standard defines */
 #if !defined(INT64_MAX)


### PR DESCRIPTION
This is often defined in various places, add a definition check to make
sure it is not already defined.

This will be needed for the Zephyr RTOS port.