### PR TITLE
Zephyr RTOS port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
 # Make sure we can import out CMake functions
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 # Load in the needed CMake modules
 include(CheckIncludeFiles)
@@ -38,8 +38,10 @@ determine_target_architecture(CIVETWEB_ARCHITECTURE)
 include(GNUInstallDirs)
 
 # Detect the platform reliably
-if(NOT MACOSX AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-   SET(DARWIN YES)
+if(${KERNEL_NAME} MATCHES "zephyr")
+    SET(ZEPHYR YES)
+elseif(NOT MACOSX AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    SET(DARWIN YES)
 elseif(NOT BSD AND ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
     SET(FREEBSD YES)
 elseif(NOT LINUX AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
@@ -294,27 +296,6 @@ else()
   add_c_compiler_flag(-std=${CIVETWEB_C_STANDARD})
 endif()
 
-#Warnings: enable everything
-add_c_compiler_flag(-Wall)
-add_c_compiler_flag(-Wextra)
-add_c_compiler_flag(-Wshadow)
-add_c_compiler_flag(-Wconversion)
-add_c_compiler_flag(-Wmissing-prototypes)
-add_c_compiler_flag(-Weverything)
-add_c_compiler_flag(-Wparentheses)
-add_c_compiler_flag(/W4) # VisualStudio highest warning level
-
-#Warnings: Disable some warnings
-add_c_compiler_flag(-Wno-padded) # padding in structures by compiler
-add_c_compiler_flag(-Wno-unused-macros) # so what?
-Check_C_Compiler_Flag( HAVE_NO_RESERVED_ID_MACROS -Wno-reserved-id-macros)
-if (HAVE_NO_RESERVED_ID_MACROS)
-add_c_compiler_flag(-Wno-reserved-id-macros) # for system headers
-endif (HAVE_NO_RESERVED_ID_MACROS)
-add_c_compiler_flag(-Wno-format-nonliteral) # printf(myFormatStringVar, ...)
-add_c_compiler_flag(-Wno-cast-qual) # const cast
-add_c_compiler_flag(/Wd4820) # padding
-
 if (MINGW)
   add_c_compiler_flag(-Wno-format)
 endif()
@@ -322,9 +303,6 @@ if (NOT CIVETWEB_ALLOW_WARNINGS)
   add_c_compiler_flag(-Werror)
   add_c_compiler_flag(/WX)
 endif()
-add_c_compiler_flag(-pedantic-errors)
-add_c_compiler_flag(-fvisibility=hidden)
-add_c_compiler_flag(-fstack-protector-strong RELEASE)
 if (${CIVETWEB_ENABLE_LTO})
   add_c_compiler_flag(-flto RELEASE)
 endif()
@@ -335,7 +313,6 @@ if (HAVE_C_FLAG_FSANITIZE_ADDRESS)
   add_c_compiler_flag(-static-asan DEBUG)
 endif()
 endif()
-add_c_compiler_flag(-fstack-protector-all DEBUG)
 if (MINGW)
   add_c_compiler_flag(-mwindows)
 endif()
@@ -417,6 +394,79 @@ if (CIVETWEB_ENABLE_CXX)
   add_cxx_compiler_flag(--coverage COVERAGE)
 endif()
 
+if (NOT ZEPHYR)
+  #Warnings: enable everything
+  add_c_compiler_flag(-Wall)
+  add_c_compiler_flag(-Wextra)
+  add_c_compiler_flag(-Wshadow)
+  add_c_compiler_flag(-Wconversion)
+  add_c_compiler_flag(-Wmissing-prototypes)
+  add_c_compiler_flag(-Weverything)
+  add_c_compiler_flag(-Wparentheses)
+  add_c_compiler_flag(/W4) # VisualStudio highest warning level
+
+  #Warnings: Disable some warnings
+  add_c_compiler_flag(-Wno-padded) # padding in structures by compiler
+  add_c_compiler_flag(-Wno-unused-macros) # so what?
+  Check_C_Compiler_Flag( HAVE_NO_RESERVED_ID_MACROS -Wno-reserved-id-macros)
+  if (HAVE_NO_RESERVED_ID_MACROS)
+  add_c_compiler_flag(-Wno-reserved-id-macros) # for system headers
+  endif (HAVE_NO_RESERVED_ID_MACROS)
+  add_c_compiler_flag(-Wno-format-nonliteral) # printf(myFormatStringVar, ...)
+  add_c_compiler_flag(-Wno-cast-qual) # const cast
+  add_c_compiler_flag(/Wd4820) # padding
+
+  add_c_compiler_flag(-pedantic-errors)
+  add_c_compiler_flag(-fvisibility=hidden)
+  add_c_compiler_flag(-fstack-protector-strong RELEASE)
+  add_c_compiler_flag(-fstack-protector-all DEBUG)
+else()
+  # This policy is needed to override options with variables
+  cmake_policy(SET CMP0077 NEW)
+
+  # Configure what you need/support in Zephyr
+  set(CIVETWEB_SERVE_NO_FILES ON)
+  set(CIVETWEB_SERVE_NO_FILESYSTEMS ON)
+  set(CIVETWEB_DISABLE_CGI ON)
+  set(CIVETWEB_DISABLE_CACHING ON)
+  set(CIVETWEB_ENABLE_SSL OFF)
+  set(CIVETWEB_ENABLE_SSL_DYNAMIC_LOADING OFF)
+
+  set(CIVETWEB_ENABLE_LUA OFF)
+  set(CIVETWEB_ENABLE_DUKTAPE OFF)
+  set(CIVETWEB_ENABLE_MEMORY_DEBUGGING OFF)
+  set(CIVETWEB_ENABLE_SERVER_EXECUTABLE OFF)
+  set(CIVETWEB_ENABLE_ASAN OFF)
+  set(CIVETWEB_INSTALL_EXECUTABLE OFF)
+
+  set(CIVETWEB_THREAD_STACK_SIZE 0)
+
+  set(BUILD_SHARED_LIBS OFF)
+
+  add_definitions(-DMG_EXTERNAL_FUNCTION_mg_cry_internal_impl)
+  add_definitions(-DMG_EXTERNAL_FUNCTION_log_access)
+
+  add_definitions(-DNO_ALTERNATIVE_QUEUE)
+  add_definitions(-DZEPHYR_VERSION=${KERNEL_VERSION_STRING})
+
+  zephyr_interface_library_named(CIVETWEB)
+
+  target_include_directories(CIVETWEB INTERFACE src)
+  target_include_directories(CIVETWEB INTERFACE include)
+  target_include_directories(CIVETWEB INTERFACE ${CMAKE_SOURCE_DIR}/src)
+
+  zephyr_include_directories(include)
+
+  zephyr_library()
+  zephyr_library_sources(
+    src/civetweb.c
+  )
+
+  zephyr_library_link_libraries(CIVETWEB)
+  target_link_libraries(CIVETWEB INTERFACE zephyr_interface)
+endif()
+
+
 # Set up the definitions
 if (${CMAKE_BUILD_TYPE} MATCHES "[Dd]ebug")
   add_definitions(-DDEBUG)
@@ -434,6 +484,9 @@ if (CIVETWEB_ENABLE_SERVER_STATS)
 endif()
 if (CIVETWEB_SERVE_NO_FILES)
   add_definitions(-DNO_FILES)
+endif()
+if (CIVETWEB_SERVE_NO_FILESYSTEMS)
+  add_definitions(-DNO_FILESYSTEMS)
 endif()
 if (CIVETWEB_DISABLE_CGI)
   add_definitions(-DNO_CGI)
@@ -475,6 +528,10 @@ if (${CMAKE_ARCH} MATCHES "[Xx]64")
 add_c_compiler_flag(-m64)
 endif()
 # TODO: add support for -march
+
+if (ZEPHYR)
+  return()
+endif()
 
 # Build the targets
 add_subdirectory(src)

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -13357,8 +13357,7 @@ mg_set_handler_type(struct mg_context *phys_ctx,
 	}
 
 	tmp_rh =
-	    (struct mg_handler_info *)mg_calloc_ctx(sizeof(struct mg_handler_info),
-	                                            1,
+	    (struct mg_handler_info *)mg_calloc_ctx(1, sizeof(struct mg_handler_info),
 	                                            phys_ctx);
 	if (tmp_rh == NULL) {
 		mg_unlock_context(phys_ctx);
@@ -18660,8 +18659,8 @@ mg_start(const struct mg_callbacks *callbacks,
 
 #if defined(ALTERNATIVE_QUEUE)
 	ctx->client_wait_events =
-	    (void **)mg_calloc_ctx(sizeof(ctx->client_wait_events[0]),
-	                           ctx->cfg_worker_threads,
+	    (void **)mg_calloc_ctx(ctx->cfg_worker_threads,
+	                           sizeof(ctx->client_wait_events[0]),
 	                           ctx);
 	if (ctx->client_wait_events == NULL) {
 		mg_cry_ctx_internal(ctx,
@@ -18674,8 +18673,8 @@ mg_start(const struct mg_callbacks *callbacks,
 	}
 
 	ctx->client_socks =
-	    (struct socket *)mg_calloc_ctx(sizeof(ctx->client_socks[0]),
-	                                   ctx->cfg_worker_threads,
+	    (struct socket *)mg_calloc_ctx(ctx->cfg_worker_threads,
+	                                   sizeof(ctx->client_socks[0]),
 	                                   ctx);
 	if (ctx->client_socks == NULL) {
 		mg_cry_ctx_internal(ctx,

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -14305,6 +14305,7 @@ parse_port_string(const struct vec *vec, struct socket *so, int *ip_version)
 	unsigned int a, b, c, d, port;
 	int ch, len;
 	const char *cb;
+	char *endptr;
 #if defined(USE_IPV6)
 	char buf[100] = {0};
 #endif
@@ -14358,7 +14359,9 @@ parse_port_string(const struct vec *vec, struct socket *so, int *ip_version)
 		*ip_version = 4;
 #endif
 
-	} else if (sscanf(vec->ptr, "%u%n", &port, &len) == 1) {
+	} else if (is_valid_port(port = strtoul(vec->ptr, &endptr, 0))
+		   && vec->ptr != endptr) {
+		len = endptr - vec->ptr;
 		/* If only port is specified, bind to IPv4, INADDR_ANY */
 		so->lsa.sin.sin_port = htons((uint16_t)port);
 		*ip_version = 4;

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,2 @@
+build:
+  cmake: .


### PR DESCRIPTION
This PR adds support for Zephyr RTOS. It also adds some meta-files to make civetweb usable as an externally usable Zephyr module. It was tested on Sam E70 Xplained board.

Note that the work on the side of Zephyr is not really finished (see: https://github.com/zephyrproject-rtos/zephyr/pull/17019)

Here is the main issue that sums up the porting efforts on the side of Zephyr: https://github.com/zephyrproject-rtos/zephyr/issues/16683 - all the individual issues are referenced there.

Some of the changes here (for example the change from sscanf to atoi in one of the lines, or the way the stacks for worker threads are indexed for zephyr) can be removed once the Zephyr side is fully finished.

You can also see that lots of the includes have been moved around. This is to minimize slicing the code with Zephyr related ifdefs (which there are still many).

If you have any initial comments we will be happy to hear them.
It is probably a good idea to wait for at least some initial comments from the reviewers in Zephyr before doing anything with this.

CC: @laperie @jukkar @PiotrZierhoffer