### PR TITLE
make SOMAXCONN configurable (fix 775)

### DIFF
--- a/resources/civetweb.conf
+++ b/resources/civetweb.conf
@@ -30,3 +30,4 @@ listening_ports 8080
 # url_rewrite_patterns 
 # hide_files_patterns 
 # request_timeout_ms 30000
+# max_connections 100

--- a/unittest/private.c
+++ b/unittest/private.c
@@ -988,6 +988,7 @@ START_TEST(test_config_options)
 	ck_assert_str_eq("keep_alive_timeout_ms",
 	                 config_options[KEEP_ALIVE_TIMEOUT].name);
 	ck_assert_str_eq("linger_timeout_ms", config_options[LINGER_TIMEOUT].name);
+	ck_assert_str_eq("max_connections", config_options[MAX_CONNECTIONS].name);
 	ck_assert_str_eq("ssl_verify_peer",
 	                 config_options[SSL_DO_VERIFY_PEER].name);
 	ck_assert_str_eq("ssl_ca_path", config_options[SSL_CA_PATH].name);


### PR DESCRIPTION
Adds a configurable "max_connections" parameter that allows user-tuneable SOMAXCONN.

See-also:
https://github.com/civetweb/civetweb/issues/775