### PR TITLE
Optimize CivetServer::getPostData

### DIFF
--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -584,7 +584,7 @@ CivetServer::getPostData(struct mg_connection *conn)
 	char buf[2048];
 	int r = mg_read(conn, buf, sizeof(buf));
 	while (r > 0) {
-		postdata += std::string(buf, r);
+		postdata.append(buf, r);
 		r = mg_read(conn, buf, sizeof(buf));
 	}
 	mg_unlock_connection(conn);


### PR DESCRIPTION
Use `std::string::append` instead of creating `std::string` object for each append.