### PR TITLE
Add static_file_cache_control config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -269,3 +269,9 @@ ci/lua
 
 # Conan test cache
 conan/test_package/build
+
+
+##########################
+## Visual Studio Code
+##########################
+.vscode

--- a/docs/UserManual.md
+++ b/docs/UserManual.md
@@ -617,6 +617,18 @@ than the depth set here connection is refused.
 ### ssl\_verify\_peer `no`
 Enable client's certificate verification by the server.
 
+### static\_file\_cache\_control
+Set the `Cache-Control` header of static files responses.
+The string value will be used directly.
+
+E.g. this config:
+static_file_cache_control no-cache, max-age=31536000
+
+Will result in this header being added:
+Cache-Control: no-cache, max-age=31536000
+
+This will take precedence over the static\_file\_max\_age option.
+
 ### static\_file\_max\_age `3600`
 Set the maximum time (in seconds) a cache may store a static files.
 
@@ -626,7 +638,7 @@ must send cache control headers by themselves.
 
 A value >0 corresponds to a maximum allowed caching time in seconds.
 This value should not exceed one year (RFC 2616, Section 14.21).
-A value of 0 will send "do not cache" headers for all static files.
+A value of 0 will send "do not cache at all" headers for all static files.
 For values <0 and values >31622400, the behaviour is undefined.
 
 ### strict\_transport\_security\_max\_age

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -2439,6 +2439,7 @@ enum {
 	ERROR_PAGES,
 #if !defined(NO_CACHING)
 	STATIC_FILE_MAX_AGE,
+	STATIC_FILE_CACHE_CONTROL,
 #endif
 #if !defined(NO_SSL)
 	STRICT_HTTPS_MAX_AGE,
@@ -2555,6 +2556,7 @@ static const struct mg_option config_options[] = {
     {"error_pages", MG_CONFIG_TYPE_DIRECTORY, NULL},
 #if !defined(NO_CACHING)
     {"static_file_max_age", MG_CONFIG_TYPE_NUMBER, "3600"},
+	{"static_file_cache_control", MG_CONFIG_TYPE_STRING, NULL},
 #endif
 #if !defined(NO_SSL)
     {"strict_transport_security_max_age", MG_CONFIG_TYPE_NUMBER, NULL},
@@ -4353,6 +4355,10 @@ static int
 send_static_cache_header(struct mg_connection *conn)
 {
 #if !defined(NO_CACHING)
+	const char *cache_control = conn->dom_ctx->config[STATIC_FILE_CACHE_CONTROL];
+	if (cache_control != NULL) {
+		return mg_printf(conn, "Cache-Control: %s\r\n", cache_control);
+	}
 	/* Read the server config to check how long a file may be cached.
 	 * The configuration is in seconds. */
 	int max_age = atoi(conn->dom_ctx->config[STATIC_FILE_MAX_AGE]);


### PR DESCRIPTION
Solves #801

Add a config option for adding an arbitrary Cache-Control header to static file responses.