### PR TITLE
Use new .dll names on Windows x64 for OpenSSL 1.1.x

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -569,19 +569,27 @@ typedef long off_t;
 
 #if defined(_WIN64) || defined(__MINGW64__)
 #if !defined(SSL_LIB)
+#if defined(OPENSSL_API_1_1)
+#define SSL_LIB "libssl-1_1-x64.dll"
+#else /* OPENSSL_API_1_1 */
 #define SSL_LIB "ssleay64.dll"
-#endif
+#endif /* OPENSSL_API_1_1 */
+#endif /* SSL_LIB */
 #if !defined(CRYPTO_LIB)
+#if defined(OPENSSL_API_1_1)
+#define CRYPTO_LIB "libcrypto-1_1-x64.dll"
+#else /* OPENSSL_API_1_1 */
 #define CRYPTO_LIB "libeay64.dll"
-#endif
-#else
+#endif /* OPENSSL_API_1_1 */
+#endif /* CRYPTO_LIB */
+#else /* defined(_WIN64) || defined(__MINGW64__) */
 #if !defined(SSL_LIB)
 #define SSL_LIB "ssleay32.dll"
-#endif
+#endif /* SSL_LIB */
 #if !defined(CRYPTO_LIB)
 #define CRYPTO_LIB "libeay32.dll"
-#endif
-#endif
+#endif /* CRYPTO_LIB */
+#endif /* defined(_WIN64) || defined(__MINGW64__) */
 
 #define O_NONBLOCK (0)
 #if !defined(W_OK)


### PR DESCRIPTION
Hi, I ran into an issue while using civetweb on Windows to host a server over https and the issue ended up being that civetweb was looking for the old OpenSSL (<=1.1.0) dlls. So I cloned civetweb and applied the following changes and recompiled with the OPENSSL_API_1_1 flag and it seemed to fix my problem. I thought it might be useful for others so I decided to make this pull request.

Please let me know if there are any changes I should make or potential concerns with it. Thank you.

Original commit message:
```
In OpenSSL 1.1.x, the following .dlls have new names:
    libeay64.dll -> libcrypto-1_1-x64.dll
    ssleay64.dll -> libssl-1_1-x64.dll

While work was done in https://github.com/civetweb/civetweb/issues/370
(commit 0733fae) to have civetweb use OpenSSL 1.1.x's new API, the
Windows .dll names were not changed. This causes civetweb to throw an
error since it can't find libeay or ssleay. A workaround would be to
copy the new dlls and rename them as the old .dlls. With this commit,
such a workaround is no longer necessary if civetweb is build with the
OPENSSL_API_1_1 flag.

See https://mta.openssl.org/pipermail/openssl-users/2017-June/005977.html
for more details about the relevant OpenSSL change.
```