### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -17,6 +17,19 @@ Instructions for adding SSL support can be found in [https://github.com/civetweb
 2. Download latest *civetweb-win.zip* from [SourceForge](https://sourceforge.net/projects/civetweb/files/)
 3. When started, Civetweb puts itself into the tray.
 
+Building civetweb - Using vcpkg
+---
+
+You can download and install civetweb using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install civetweb
+
+The civetweb port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 OS X
 ---
 


### PR DESCRIPTION
Civetweb is available as a port in vcpkg, a C++ library manager that simplifies installation for civetweb and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build civetweb, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.