### PR TITLE
use DEBUG_TRACE_STREAM instead of stdout in DEBUG_TRACE_FUNC, still d…

### DIFF
--- a/docs/api/mg_get_server_ports.md
+++ b/docs/api/mg_get_server_ports.md
@@ -7,7 +7,7 @@
 | Parameter | Type | Description |
 | :--- | :--- | :--- |
 |**`ctx`**|`const struct mg_context *`|The context for which the server ports are requested|
-|**`size`**|`int`|The size of the buffer to store the port information|
+|**`size`**|`unsigned int`|The size of the buffer to store the port information|
 |**`ports`**|`struct mg_server_port *`|Buffer to store the port information|
 
 ### Return Value

--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -754,7 +754,7 @@ struct mg_server_port {
    This function returns the number of struct mg_server_port elements
    filled in, or <0 in case of an error. */
 CIVETWEB_API int mg_get_server_ports(const struct mg_context *ctx,
-                                     int size,
+                                     unsigned int size,
                                      struct mg_server_port *ports);
 
 

--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -638,7 +638,7 @@ CivetServer::getListeningPortsFull()
 {
 	std::vector<struct mg_server_port> server_ports(50);
 	int size = mg_get_server_ports(context,
-	                               (int)server_ports.size(),
+	                               server_ports.size(),
 	                               &server_ports[0]);
 	if (size <= 0) {
 		server_ports.resize(0);

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -3628,15 +3628,14 @@ mg_get_ports(const struct mg_context *ctx, size_t size, int *ports, int *ssl)
 
 int
 mg_get_server_ports(const struct mg_context *ctx,
-                    int size,
+                    unsigned int size,
                     struct mg_server_port *ports)
 {
-	int i, cnt = 0;
+	unsigned int i;
 
-	if (size <= 0) {
-		return -1;
+	if (size == 0) {
+		return ctx->num_listening_sockets;
 	}
-	memset(ports, 0, sizeof(*ports) * (size_t)size);
 	if (!ctx) {
 		return -1;
 	}
@@ -3644,30 +3643,35 @@ mg_get_server_ports(const struct mg_context *ctx,
 		return -1;
 	}
 
-	for (i = 0; (i < size) && (i < (int)ctx->num_listening_sockets); i++) {
+   // what for ?
+   memset( ports, 0, sizeof(*ports) * size);
 
-		ports[cnt].port =
+   if( ctx->num_listening_sockets < size)
+      size = ctx->num_listening_sockets;
+
+	for (i = 0; i < size; i++) {
+
+		ports[i].port =
 #if defined(USE_IPV6)
 		    (ctx->listening_sockets[i].lsa.sa.sa_family == AF_INET6)
 		        ? ntohs(ctx->listening_sockets[i].lsa.sin6.sin6_port)
 		        :
 #endif
 		        ntohs(ctx->listening_sockets[i].lsa.sin.sin_port);
-		ports[cnt].is_ssl = ctx->listening_sockets[i].is_ssl;
-		ports[cnt].is_redirect = ctx->listening_sockets[i].ssl_redir;
+		ports[i].is_ssl = ctx->listening_sockets[i].is_ssl;
+		ports[i].is_redirect = ctx->listening_sockets[i].ssl_redir;
 
 		if (ctx->listening_sockets[i].lsa.sa.sa_family == AF_INET) {
 			/* IPv4 */
-			ports[cnt].protocol = 1;
-			cnt++;
-		} else if (ctx->listening_sockets[i].lsa.sa.sa_family == AF_INET6) {
+			ports[i].protocol = 1;
+		}
+      if (ctx->listening_sockets[i].lsa.sa.sa_family == AF_INET6) {
 			/* IPv6 */
-			ports[cnt].protocol = 3;
-			cnt++;
+			ports[i].protocol += 2;
 		}
 	}
 
-	return cnt;
+	return (int) size;
 }
 
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -234,6 +234,9 @@ static void DEBUG_TRACE_FUNC(const char *func,
 	DEBUG_TRACE_FUNC(__func__, __LINE__, fmt, __VA_ARGS__)
 
 #define NEED_DEBUG_TRACE_FUNC
+#ifndef DEBUG_TRACE_STREAM
+# define DEBUG_TRACE_STREAM   stdout
+#endif
 
 #else
 #define DEBUG_TRACE(fmt, ...)                                                  \
@@ -1743,8 +1746,8 @@ DEBUG_TRACE_FUNC(const char *func, unsigned line, const char *fmt, ...)
 		nslast = nsnow;
 	}
 
-	flockfile(stdout);
-	printf("*** %lu.%09lu %12" INT64_FMT " %lu %s:%u: ",
+	flockfile(DEBUG_TRACE_STREAM);
+	fprintf( DEBUG_TRACE_STREAM,"*** %lu.%09lu %12" INT64_FMT " %lu %s:%u: ",
 	       (unsigned long)tsnow.tv_sec,
 	       (unsigned long)tsnow.tv_nsec,
 	       nsnow - nslast,
@@ -1752,11 +1755,11 @@ DEBUG_TRACE_FUNC(const char *func, unsigned line, const char *fmt, ...)
 	       func,
 	       line);
 	va_start(args, fmt);
-	vprintf(fmt, args);
+	vfprintf(DEBUG_TRACE_STREAM, fmt, args);
 	va_end(args);
-	putchar('\n');
-	fflush(stdout);
-	funlockfile(stdout);
+	putc('\n', DEBUG_TRACE_STREAM);
+	fflush(DEBUG_TRACE_STREAM);
+	funlockfile(DEBUG_TRACE_STREAM);
 	nslast = nsnow;
 }
 #endif /* NEED_DEBUG_TRACE_FUNC */


### PR DESCRIPTION
…efaults to stdout though

In my test cases, I need to use stdout for something else. Yet I would like to have `DEBUG_TRACE_FUNC` on at the same time. My solution I set `DEBUG_TRACE_STREAM` to `stderr`. This patch enables this.