### PR TITLE
Start master_thread after worker threads to avoid data race on worker_threadids

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -19606,9 +19606,6 @@ static
 	ctx->callbacks.exit_context = exit_callback;
 	ctx->context_type = CONTEXT_SERVER; /* server context */
 
-	/* Start master (listening) thread */
-	mg_start_thread_with_id(master_thread, ctx, &ctx->masterthreadid);
-
 	/* Start worker threads */
 	for (i = 0; i < ctx->cfg_worker_threads; i++) {
 		/* worker_thread sets up the other fields */
@@ -19657,6 +19654,9 @@ static
 			break;
 		}
 	}
+
+    /* Start master (listening) thread */
+    mg_start_thread_with_id(master_thread, ctx, &ctx->masterthreadid);
 
 	pthread_setspecific(sTlsKey, NULL);
 	return ctx;


### PR DESCRIPTION
See the following TSAN report

```
WARNING: ThreadSanitizer: data race (pid=745240)
  Read of size 8 at 0x7b08000006d8 by thread T1:
    #0 master_thread_run civetweb/src/civetweb.c:18665:7 (objectbox-http-server-test+0x2781ec)
    #1 master_thread civetweb/src/civetweb.c:18725:2 (objectbox-http-server-test+0x2781ec)

  Previous write of size 8 at 0x7b08000006d8 by main thread:
    #0 mg_start_thread_with_id civetweb/src/civetweb.c:6052:16 (objectbox-http-server-test+0x26ea67)
    #1 mg_start2 civetweb/src/civetweb.c:19488:7 (objectbox-http-server-test+0x26ea67)
    #2 mg_start civetweb/src/civetweb.c:19548:9 (objectbox-http-server-test+0x26ea67)
    #3 CivetServer::CivetServer(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, CivetCallbacks const*, void const*) civetweb/src/CivetServer.cpp:321:12 (objectbox-http-server-test+0x2830de)

  Location is heap block of size 32 at 0x7b08000006c0 allocated by main thread:
    #0 calloc <null> (objectbox-http-server-test+0x7b468)
    #1 mg_calloc civetweb/src/civetweb.c:1540:9 (objectbox-http-server-test+0x26e864)
    #2 mg_start2 civetweb/src/civetweb.c:19336:39 (objectbox-http-server-test+0x26e864)
    #3 mg_start civetweb/src/civetweb.c:19548:9 (objectbox-http-server-test+0x26e864)
    #4 CivetServer::CivetServer(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, CivetCallbacks const*, void const*) civetweb/src/CivetServer.cpp:321:12 (objectbox-http-server-test+0x2830de)

  Thread T1 'civetweb-master' (tid=745245, running) created by main thread at:
    #0 pthread_create <null> (objectbox-http-server-test+0xb07ce)
    #1 mg_start_thread_with_id civetweb/src/civetweb.c:6049:11 (objectbox-http-server-test+0x26e920)
    #2 mg_start2 civetweb/src/civetweb.c:19482:2 (objectbox-http-server-test+0x26e920)
    #3 mg_start civetweb/src/civetweb.c:19548:9 (objectbox-http-server-test+0x26e920)
    #4 CivetServer::CivetServer(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, CivetCallbacks const*, void const*) civetweb/src/CivetServer.cpp:321:12 (objectbox-http-server-test+0x2830de)

SUMMARY: ThreadSanitizer: data race civetweb/src/civetweb.c:18665:7 in master_thread_run
```