### PR TITLE
Need the timegm stub on Solaris

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -59,7 +59,7 @@
 #if defined(__linux__) && !defined(_XOPEN_SOURCE)
 #define _XOPEN_SOURCE 600 /* For flockfile() on Linux */
 #endif
-#if defined(__LSB_VERSION__)
+#if defined(__LSB_VERSION__) || defined(__sun)
 #define NEED_TIMEGM
 #define NO_THREAD_NAME
 #endif


### PR DESCRIPTION
This is Solaris 10 and gcc 5.5.50 from opencsw.