### PR TITLE
Fix a potential buffer overflow in unit test

### DIFF
--- a/unittest/shared.c
+++ b/unittest/shared.c
@@ -44,5 +44,5 @@ set_test_directory(const char *const path)
 {
 	strncpy(s_test_directory,
 	        path,
-	        sizeof(s_test_directory) / sizeof(s_test_directory[0]));
+	        sizeof(s_test_directory) - 1);
 }


### PR DESCRIPTION
strncpy wouldn't append the null byte in case the source
string length is >= destination buffer.

's_test_directory' is already zero initialized. So leaving
the last byte alone is enough ensure the buffer is null byte
terminated in the worse case.

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>