### PR TITLE
embedded_cpp.cpp: fix sleep time

### DIFF
--- a/examples/embedded_cpp/embedded_cpp.cpp
+++ b/examples/embedded_cpp/embedded_cpp.cpp
@@ -433,9 +433,9 @@ main(int argc, char *argv[])
 
 	while (!exitNow) {
 #ifdef _WIN32
-		Sleep(1000);
+		Sleep(1);
 #else
-		sleep(1);
+		sleep(1000);
 #endif
 	}
 


### PR DESCRIPTION
Windows `Sleep` is in milliseconds, and unix `sleep` is in microseconds.