### PR TITLE
fix: properly lookup winsock in imported project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,6 +603,9 @@ install(
   FILES
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibDL.cmake"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibRt.cmake"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindWinSock.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
   COMPONENT civetweb-cmake-config
 )

--- a/cmake/civetweb-config.cmake.in
+++ b/cmake/civetweb-config.cmake.in
@@ -3,4 +3,24 @@ include(CMakeFindDependencyMacro)
 
 set_and_check(civetweb_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 
+find_dependency(Threads)
+
+set(CIVETWEB_SAVED_MODULE_PATH ${CMAKE_MODULE_PATH})
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+if(@LOOKUP_LIBDL@)
+  find_dependency(LibDl)
+endif()
+
+if(@LOOKUP_LIBRT@)
+  find_dependency(LibRt)
+endif()
+
+if(@LOOKUP_WINSOCK@)
+  find_dependency(WinSock)
+endif()
+
+set(CMAKE_MODULE_PATH ${CIVETWEB_SAVED_MODULE_PATH})
+unset(CIVETWEB_SAVED_MODULE_PATH)
+
 include("${CMAKE_CURRENT_LIST_DIR}/civetweb-targets.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -322,3 +322,23 @@ if (CIVETWEB_ENABLE_CXX)
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     COMPONENT civetweb-cpp)
 endif()
+
+# Configure lookup behavior in civetweb config
+
+if(LIBDL_FOUND)
+  set(LOOKUP_LIBDL TRUE PARENT_SCOPE)
+else()
+  set(LOOKUP_LIBDL FALSE PARENT_SCOPE)
+endif()
+
+if(LIBRT_FOUND)
+  set(LOOKUP_LIBRT TRUE PARENT_SCOPE)
+else()
+  set(LOOKUP_LIBRT FALSE PARENT_SCOPE)
+endif()
+
+if(WINSOCK_FOUND)
+  set(LOOKUP_WINSOCK TRUE PARENT_SCOPE)
+else()
+  set(LOOKUP_WINSOCK FALSE PARENT_SCOPE)
+endif()


### PR DESCRIPTION
Hello,

I recently got a [report](jupp0r/prometheus-cpp#401) that CMake project import of civetweb fails in a MinGW environment. The root cause is that the exported civetweb config links against `WINSOCK::WINSOCK` which is unknown outside of the civetweb project.

This PR exports the publicly needed CMake find modules and looks those up on a case-by-case basis.

Thanks,
Gregor