### PR TITLE
Added overload handle functions with http status

### DIFF
--- a/include/CivetServer.h
+++ b/include/CivetServer.h
@@ -68,6 +68,16 @@ class CIVETWEB_CXX_API CivetHandler
 	virtual bool handleGet(CivetServer *server, struct mg_connection *conn);
 
 	/**
+	 * Callback method for GET request.
+	 *
+	 * @param server - the calling server
+	 * @param conn - the connection information
+	 * @param http - pointer to return status code
+	 * @returns true if implemented, false otherwise
+	 */
+	virtual bool handleGet(CivetServer *server, struct mg_connection *conn, int *status_code);
+
+	/**
 	 * Callback method for POST request.
 	 *
 	 * @param server - the calling server
@@ -75,6 +85,16 @@ class CIVETWEB_CXX_API CivetHandler
 	 * @returns true if implemented, false otherwise
 	 */
 	virtual bool handlePost(CivetServer *server, struct mg_connection *conn);
+
+	/**
+	 * Callback method for POST request.
+	 *
+	 * @param server - the calling server
+	 * @param conn - the connection information
+	 * @param http - pointer to return status code
+	 * @returns true if implemented, false otherwise
+	 */
+	virtual bool handlePost(CivetServer *server, struct mg_connection *conn, int *status_code);
 
 	/**
 	 * Callback method for HEAD request.
@@ -86,6 +106,16 @@ class CIVETWEB_CXX_API CivetHandler
 	virtual bool handleHead(CivetServer *server, struct mg_connection *conn);
 
 	/**
+	 * Callback method for HEAD request.
+	 *
+	 * @param server - the calling server
+	 * @param conn - the connection information
+	 * @param http - pointer to return status code
+	 * @returns true if implemented, false otherwise
+	 */
+	virtual bool handleHead(CivetServer *server, struct mg_connection *conn, int *status_code);
+
+	/**
 	 * Callback method for PUT request.
 	 *
 	 * @param server - the calling server
@@ -93,6 +123,16 @@ class CIVETWEB_CXX_API CivetHandler
 	 * @returns true if implemented, false otherwise
 	 */
 	virtual bool handlePut(CivetServer *server, struct mg_connection *conn);
+
+	/**
+	 * Callback method for PUT request.
+	 *
+	 * @param server - the calling server
+	 * @param conn - the connection information
+	 * @param http - pointer to return status code
+	 * @returns true if implemented, false otherwise
+	 */
+	virtual bool handlePut(CivetServer *server, struct mg_connection *conn, int *status_code);
 
 	/**
 	 * Callback method for DELETE request.
@@ -104,6 +144,16 @@ class CIVETWEB_CXX_API CivetHandler
 	virtual bool handleDelete(CivetServer *server, struct mg_connection *conn);
 
 	/**
+	 * Callback method for DELETE request.
+	 *
+	 * @param server - the calling server
+	 * @param conn - the connection information
+	 * @param http - pointer to return status code
+	 * @returns true if implemented, false otherwise
+	 */
+	virtual bool handleDelete(CivetServer *server, struct mg_connection *conn, int *status_code);
+
+	/**
 	 * Callback method for OPTIONS request.
 	 *
 	 * @param server - the calling server
@@ -113,6 +163,16 @@ class CIVETWEB_CXX_API CivetHandler
 	virtual bool handleOptions(CivetServer *server, struct mg_connection *conn);
 
 	/**
+	 * Callback method for OPTIONS request.
+	 *
+	 * @param server - the calling server
+	 * @param conn - the connection information
+	 * @param http - pointer to return status code
+	 * @returns true if implemented, false otherwise
+	 */
+	virtual bool handleOptions(CivetServer *server, struct mg_connection *conn, int *status_code);
+
+	/**
 	 * Callback method for PATCH request.
 	 *
 	 * @param server - the calling server
@@ -120,6 +180,16 @@ class CIVETWEB_CXX_API CivetHandler
 	 * @returns true if implemented, false otherwise
 	 */
 	virtual bool handlePatch(CivetServer *server, struct mg_connection *conn);
+
+	/**
+	 * Callback method for PATCH request.
+	 *
+	 * @param server - the calling server
+	 * @param conn - the connection information
+	 * @param http - pointer to return status code
+	 * @returns true if implemented, false otherwise
+	 */
+	virtual bool handlePatch(CivetServer *server, struct mg_connection *conn, int *status_code);
 };
 
 /**

--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -28,10 +28,32 @@ CivetHandler::handleGet(CivetServer *server, struct mg_connection *conn)
 }
 
 bool
+CivetHandler::handleGet(CivetServer *server, struct mg_connection *conn, int *status_code)
+{
+	UNUSED_PARAMETER(server);
+	UNUSED_PARAMETER(conn);
+	if(status_code){
+		*status_code = -1;
+	}
+	return false;
+}
+
+bool
 CivetHandler::handlePost(CivetServer *server, struct mg_connection *conn)
 {
 	UNUSED_PARAMETER(server);
 	UNUSED_PARAMETER(conn);
+	return false;
+}
+
+bool
+CivetHandler::handlePost(CivetServer *server, struct mg_connection *conn, int *status_code)
+{
+	UNUSED_PARAMETER(server);
+	UNUSED_PARAMETER(conn);
+	if(status_code){
+		*status_code = -1;
+	}
 	return false;
 }
 
@@ -44,10 +66,32 @@ CivetHandler::handleHead(CivetServer *server, struct mg_connection *conn)
 }
 
 bool
+CivetHandler::handleHead(CivetServer *server, struct mg_connection *conn, int *status_code)
+{
+	UNUSED_PARAMETER(server);
+	UNUSED_PARAMETER(conn);
+		if(status_code){
+		*status_code = -1;
+	}
+	return false;
+}
+
+bool
 CivetHandler::handlePut(CivetServer *server, struct mg_connection *conn)
 {
 	UNUSED_PARAMETER(server);
 	UNUSED_PARAMETER(conn);
+	return false;
+}
+
+bool
+CivetHandler::handlePut(CivetServer *server, struct mg_connection *conn, int *status_code)
+{
+	UNUSED_PARAMETER(server);
+	UNUSED_PARAMETER(conn);
+	if(status_code){
+		*status_code = -1;
+	}
 	return false;
 }
 
@@ -60,10 +104,32 @@ CivetHandler::handlePatch(CivetServer *server, struct mg_connection *conn)
 }
 
 bool
+CivetHandler::handlePatch(CivetServer *server, struct mg_connection *conn, int *status_code)
+{
+	UNUSED_PARAMETER(server);
+	UNUSED_PARAMETER(conn);
+	if(status_code){
+		*status_code = -1;
+	}
+	return false;
+}
+
+bool
 CivetHandler::handleDelete(CivetServer *server, struct mg_connection *conn)
 {
 	UNUSED_PARAMETER(server);
 	UNUSED_PARAMETER(conn);
+	return false;
+}
+
+bool
+CivetHandler::handleDelete(CivetServer *server, struct mg_connection *conn, int *status_code)
+{
+	UNUSED_PARAMETER(server);
+	UNUSED_PARAMETER(conn);
+	if(status_code){
+		*status_code = -1;
+	}
 	return false;
 }
 
@@ -73,6 +139,17 @@ CivetHandler::handleOptions(CivetServer *server, struct mg_connection *conn)
 	UNUSED_PARAMETER(server);
 	UNUSED_PARAMETER(conn);
 	return false;
+}
+
+bool
+CivetHandler::handleOptions(CivetServer *server, struct mg_connection *conn, int *status_code)
+{
+	UNUSED_PARAMETER(server);
+	UNUSED_PARAMETER(conn);
+	if(status_code){
+		*status_code = -1;
+	}
+	return -1;
 }
 
 bool
@@ -124,6 +201,8 @@ CivetServer::requestHandler(struct mg_connection *conn, void *cbdata)
 	assert(request_info != NULL);
 	CivetServer *me = (CivetServer *)(request_info->user_data);
 	assert(me != NULL);
+	int http_status_code = -1;
+	bool status_ok = false;
 
 	// Happens when a request hits the server before the context is saved
 	if (me->context == NULL)
@@ -137,23 +216,48 @@ CivetServer::requestHandler(struct mg_connection *conn, void *cbdata)
 
 	if (handler) {
 		if (strcmp(request_info->request_method, "GET") == 0) {
-			return handler->handleGet(me, conn) ? 1 : 0;
+			status_ok = handler->handleGet(me, conn,&http_status_code);
+			if(http_status_code < 0){
+				status_ok = handler->handleGet(me, conn);
+			}
 		} else if (strcmp(request_info->request_method, "POST") == 0) {
-			return handler->handlePost(me, conn) ? 1 : 0;
+			status_ok = handler->handlePost(me, conn,&http_status_code);
+			if(http_status_code < 0){
+				status_ok = handler->handlePost(me, conn);
+			}
 		} else if (strcmp(request_info->request_method, "HEAD") == 0) {
-			return handler->handleHead(me, conn) ? 1 : 0;
+			status_ok = handler->handleHead(me, conn,&http_status_code);
+			if(http_status_code < 0){
+				status_ok = handler->handleHead(me, conn);
+			}
 		} else if (strcmp(request_info->request_method, "PUT") == 0) {
-			return handler->handlePut(me, conn) ? 1 : 0;
+			status_ok = handler->handlePut(me, conn,&http_status_code);
+			if(http_status_code < 0){
+				status_ok = handler->handlePut(me, conn);
+			}
 		} else if (strcmp(request_info->request_method, "DELETE") == 0) {
-			return handler->handleDelete(me, conn) ? 1 : 0;
+			status_ok = handler->handleDelete(me, conn,&http_status_code);
+			if(http_status_code < 0){
+				status_ok = handler->handleDelete(me, conn);
+			}
 		} else if (strcmp(request_info->request_method, "OPTIONS") == 0) {
-			return handler->handleOptions(me, conn) ? 1 : 0;
+			status_ok = handler->handleOptions(me, conn,&http_status_code);
+			if(http_status_code < 0){
+				status_ok = handler->handleOptions(me, conn);
+			}
 		} else if (strcmp(request_info->request_method, "PATCH") == 0) {
-			return handler->handlePatch(me, conn) ? 1 : 0;
+			status_ok = handler->handlePatch(me, conn,&http_status_code);
+			if(http_status_code < 0){
+				status_ok = handler->handlePatch(me, conn);
+			}
 		}
 	}
 
-	return 0; // No handler found
+	if(http_status_code < 0){
+		http_status_code = status_ok ? 1 : 0;
+	}
+
+	return http_status_code;
 }
 
 int


### PR DESCRIPTION
The CivetHandler has been extended with overloaded handleGet, handlePut,
handlePatch ... functions with extra int *http_status argument.

This allows applications to return a valid HTTP status code if a resource is
not found or an operation is forbidden.