### PR TITLE
Stop flag lock - fix missing functions

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -1317,7 +1317,7 @@ mg_atomic_dec(volatile ptrdiff_t *addr)
 }
 
 
-#if defined(USE_SERVER_STATS)
+#if defined(USE_SERVER_STATS) || defined(STOP_FLAG_NEEDS_LOCK)
 static ptrdiff_t
 mg_atomic_add(volatile ptrdiff_t *addr, ptrdiff_t value)
 {


### PR DESCRIPTION
I see the stop flag can be now optionally switched from volatile to atomic/lock protected :+1: 

However, adding the flag `-DSTOP_FLAG_NEEDS_LOCK` actually breaks the build:
```
...
src/civetweb.c:2898:19: warning: implicit declaration of function 'mg_atomic_add' is invalid in C99 [-Wimplicit-function-declaration]
        stop_flag_t sf = mg_atomic_add(f, 0);
                         ^
src/civetweb.c:2905:19: warning: implicit declaration of function 'mg_atomic_add' is invalid in C99 [-Wimplicit-function-declaration]
        stop_flag_t sf = mg_atomic_add(f, 0);
                         ^
src/civetweb.c:2914:8: warning: implicit declaration of function 'mg_atomic_compare_and_swap' is invalid in C99 [-Wimplicit-function-declaration]
                sf = mg_atomic_compare_and_swap(f, *f, v);
                     ^
...
```