### PR TITLE
Adding HTTP methods for write access to files in WEBDAV

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -10948,8 +10948,13 @@ static const struct mg_http_method_info http_methods[] = {
      * Section 9.1 of [RFC2616]). Responses to this
      * method MUST NOT be cached. */
 
+    /* Methods for write access to files on WEBDAV (RFC 2518) */
+    {"LOCK", 1, 1, 0, 0, 0},
+    {"UNLOCK", 1, 0, 0, 0, 0},
+    {"PROPPATCH", 1, 1, 0, 0, 0},
+
     /* Unsupported WEBDAV Methods: */
-    /* PROPPATCH, COPY, MOVE, LOCK, UNLOCK (RFC 2518) */
+    /* COPY, MOVE (RFC 2518) */
     /* + 11 methods from RFC 3253 */
     /* ORDERPATCH (RFC 3648) */
     /* ACL (RFC 3744) */


### PR DESCRIPTION
This modification is successfully used in the context of the [WEBDAV server of Orthanc](https://book.orthanc-server.com/users/webdav.html) (DICOM server for medical imaging).