### PR TITLE
Added interface to disable keep_alive on a per-connection basis

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -1669,6 +1669,15 @@ CIVETWEB_API int
 mg_get_context_info(const struct mg_context *ctx, char *buffer, int buflen);
 
 
+/* Disable HTTP keep-alive on a per-connection basis.
+   Reference: https://github.com/civetweb/civetweb/issues/727
+   Parameters:
+     conn: Current connection handle.
+*/
+CIVETWEB_API void
+mg_disable_connection_keep_alive(struct mg_connection *conn);
+
+
 #if defined(MG_EXPERIMENTAL_INTERFACES)
 /* Get connection information. Useful for server diagnosis.
    Parameters:

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -21181,6 +21181,15 @@ mg_get_context_info(const struct mg_context *ctx, char *buffer, int buflen)
 }
 
 
+void mg_disable_connection_keep_alive(struct mg_connection *conn)
+{
+  /* https://github.com/civetweb/civetweb/issues/727 */
+  if (conn != NULL) {
+    conn->must_close = 1;
+  }
+}
+
+
 #if defined(MG_EXPERIMENTAL_INTERFACES)
 /* Get connection information. It can be printed or stored by the caller.
  * Return the size of available information. */


### PR DESCRIPTION
This changeset adds new function `mg_disable_connection_keep_alive()` to disable HTTP keep alive on a per-connection basis. Full context can be found in issue #727.