### PR TITLE
fix FindLibDl.cmake file name into the CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,7 +603,7 @@ install(
   FILES
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibDL.cmake"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibDl.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibRt.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindWinSock.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"


### PR DESCRIPTION
case sensitive file fix if installing in UNIX like system (eg: Linux)