### PR TITLE
CMake: Add option to disable Debug tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,8 +476,11 @@ endif()
 
 
 # Set up the definitions
+option(CIVETWEB_ENABLE_DEBUG_TOOLS "For Debug builds enable verbose logging and assertions" ON)
 if (${CMAKE_BUILD_TYPE} MATCHES "[Dd]ebug")
-  add_definitions(-DDEBUG)
+  if(CIVETWEB_ENABLE_DEBUG_TOOLS)
+    add_definitions(-DDEBUG)
+  endif()
   add_definitions(-O0)
   add_definitions(-g)
 endif()


### PR DESCRIPTION
Sometimes one needs the CMake `Debug` build type
to select the Windows Debug runtime. But at the same
time the verbose logging output might be unwanted.

This PR adds the `CIVETWEB_ENABLE_DEBUG_TOOLS` option
to disable extensive logging and assertion.