### PR TITLE
mbedtls: read out unprocessed TLS data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,7 +603,7 @@ install(
   FILES
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibDL.cmake"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibDl.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibRt.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindWinSock.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"

--- a/src/mod_mbedtls.inl
+++ b/src/mod_mbedtls.inl
@@ -175,7 +175,7 @@ static void
 mbed_debug(void *context, int level, const char *file, int line, const char *str)
 {
     (void)level;
-    mbedtls_fprintf((FILE *)context, "file:%s line:%d str:%s\n", file, line, str);
+    mbedtls_fprintf((FILE *)context, "file:%s line:%d str:%s", file, line, str);
 }
 
 #endif /* USE_MBEDTLS */

--- a/src/mod_mbedtls.inl
+++ b/src/mod_mbedtls.inl
@@ -51,8 +51,10 @@ mbed_sslctx_init(SSL_CTX *ctx, const char *crt)
     mbedtls_ssl_config_init(conf);
 
     // set debug level
+#if defined(CONFIG_MBEDTLS_DEBUG)
     mbedtls_debug_set_threshold(2);
     mbedtls_ssl_conf_dbg(conf, mbed_debug, stdout);
+#endif
     mbedtls_pk_init(&ctx->pkey);
     mbedtls_ctr_drbg_init(&ctx->ctr);
     mbedtls_x509_crt_init(&ctx->cert);


### PR DESCRIPTION
There can be data remaining inside TLS layer so read them out before we poll a socket