### PR TITLE
Replacing // by / is not always correct

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -8508,8 +8508,9 @@ remove_dot_segments(char *inout)
 					in++;
 				} while (in != in_ahead);
 			}
-		} else if (*in == '/') {
-			/* replace // by / */
+		} else if (*in == '/' && ((out_end != inout) && (out_end[-1] != ':'))) {
+			/* Replace // by / if not preseeded by `:` (there may be
+			 * a protocol specifier in the URL) */
 			*out_end++ = '/';
 			do {
 				in++;


### PR DESCRIPTION
We use `civetweb` to create a RESTful API for our application. Unfortunately, there is an error in how `civetweb` handles URIs.

Assume we add an URL to some lists using our (or, in fact, any RESTful API):
```
POST /api/lists/https://somedomain.com
```
(this is, of course, sent URI-encoded as `POST /api/lists/https%3A%2F%2Fsomedomain.com`)

Our API receives, however,
```
POST /api/lists/http:/somedomain.com
```
which is incorrect (mind the `https:/` with only one `/` after the `:`).

This is caused by:
https://github.com/civetweb/civetweb/blob/98abdf96a30ac2b8a8ffbd68329a43e1f0bc987c/src/civetweb.c#L8484-L8487
https://github.com/civetweb/civetweb/blob/98abdf96a30ac2b8a8ffbd68329a43e1f0bc987c/src/civetweb.c#L8511-L8520

---

Possible solutions:

1. Removing this `else if` solves the problem for us (simple fix)
2. Check if the `//` is intended as they are following a `:` and correspond to a protocol where we should accept them (minimal changes fix without introducing a new option) <- this is what this PR adds