### PR TITLE
Fix for failing to build in Debug on Mac Big Sur (v11.2.1) using clang 11.0.0

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -248,6 +248,7 @@ static void DEBUG_TRACE_FUNC(const char *func,
 
 #if !defined(DEBUG_ASSERT)
 #if defined(DEBUG)
+#include <stdlib.h>
 #define DEBUG_ASSERT(cond)                                                     \
 	do {                                                                       \
 		if (!(cond)) {                                                         \


### PR DESCRIPTION
As mentioned in subject line, when building in debug for Mac using clang 11, the build fails with
<img width="998" alt="Screen Shot 2021-02-18 at 9 19 31 AM" src="https://user-images.githubusercontent.com/8174404/108412012-c14db480-71d5-11eb-8c1d-01001d3ba2a7.png">

Adding the include fixes the error
