### PR TITLE
Add dedicated raw (local) URI variable

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -151,10 +151,10 @@ struct mg_request_info {
 	const char *request_method;  /* "GET", "POST", etc */
 	const char *request_uri;     /* URL-decoded URI (absolute or relative,
 	                              * as in the request) */
-	char *local_uri_raw;         /* URL-decoded URI (relative). Can be NULL
+	const char *local_uri_raw;   /* URL-decoded URI (relative). Can be NULL
 	                              * if the request_uri does not address a
 	                              * resource at the server host. */
-	const char *local_uri;       /* Same as local_uri_raw, however, cleaned
+	char *local_uri;             /* Same as local_uri_raw, however, cleaned
 	                              * so a path like
 	                              *   allowed_dir/../forbidden_file
 	                              * is not possible */

--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -151,9 +151,13 @@ struct mg_request_info {
 	const char *request_method;  /* "GET", "POST", etc */
 	const char *request_uri;     /* URL-decoded URI (absolute or relative,
 	                              * as in the request) */
-	const char *local_uri;       /* URL-decoded URI (relative). Can be NULL
+	char *local_uri_raw;         /* URL-decoded URI (relative). Can be NULL
 	                              * if the request_uri does not address a
 	                              * resource at the server host. */
+	const char *local_uri;       /* Same as local_uri_raw, however, cleaned
+	                              * so a path like
+	                              *   allowed_dir/../forbidden_file
+	                              * is not possible */
 #if defined(MG_LEGACY_INTERFACE) /* 2017-02-04, deprecated 2014-09-14 */
 	const char *uri;             /* Deprecated: use local_uri instead */
 #endif

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -3677,8 +3677,9 @@ mg_get_request_info(const struct mg_connection *conn)
 		}
 
 		((struct mg_connection *)conn)->request_info.local_uri =
-		    ((struct mg_connection *)conn)->request_info.request_uri =
-		        tls->txtbuf; /* use thread safe buffer */
+		    ((struct mg_connection *)conn)->request_info.local_uri_raw =
+		        ((struct mg_connection *)conn)->request_info.request_uri =
+		            tls->txtbuf; /* use thread safe buffer */
 
 		((struct mg_connection *)conn)->request_info.num_headers =
 		    conn->response_info.num_headers;
@@ -14084,10 +14085,14 @@ handle_request(struct mg_connection *conn)
 		}
 	}
 
-	/* 1.4. clean URIs, so a path like allowed_dir/../forbidden_file is
-	 * not possible */
-	ri->local_uri_raw = mg_strdup(ri->local_uri);
-	remove_dot_segments((char *)ri->local_uri);
+	/* 1.4. clean URIs, so a path like allowed_dir/../forbidden_file is not
+	 * possible. The fact that we cleaned the URI is stored in that the
+	 * pointer to ri->local_ur and ri->local_uri_raw are now different.
+	 * ri->local_uri_raw still points to memory allocated in
+	 * worker_thread_run(). ri->local_uri is private to the request so we
+	 * don't have to use preallocated memory here. */
+	ri->local_uri = mg_strdup(ri->local_uri_raw);
+	remove_dot_segments(ri->local_uri);
 
 	/* step 1. completed, the url is known now */
 	uri_len = (int)strlen(ri->local_uri);
@@ -16815,14 +16820,14 @@ reset_per_request_attributes(struct mg_connection *conn)
 	conn->request_info.remote_user = NULL;
 	conn->request_info.request_method = NULL;
 	conn->request_info.request_uri = NULL;
-	conn->request_info.local_uri = NULL;
 
-	/* Free local URI in raw form (if any) */
-	if(conn->request_info.local_uri_raw != NULL)
+	/* Free cleaned local URI (if any) */
+	if(conn->request_info.local_uri != conn->request_info.local_uri_raw)
 	{
-		mg_free(conn->request_info.local_uri_raw);
-		conn->request_info.local_uri_raw = NULL;
+		mg_free(conn->request_info.local_uri);
+		conn->request_info.local_uri = NULL;
 	}
+	conn->request_info.local_uri = NULL;
 
 #if defined(MG_LEGACY_INTERFACE)
 	/* Legacy before split into local_uri and request_uri */
@@ -17915,7 +17920,8 @@ mg_get_response(struct mg_connection *conn,
 	 *       2) here, ri.uri is the http response code */
 	conn->request_info.uri = conn->request_info.request_uri;
 #endif
-	conn->request_info.local_uri = conn->request_info.request_uri;
+	conn->request_info.local_uri_raw = conn->request_info.request_uri;
+	conn->request_info.local_uri = (char*)conn->request_info.local_uri_raw;
 
 	/* TODO (mid): Define proper return values - maybe return length?
 	 * For the first test use <0 for error and >0 for OK */
@@ -17965,7 +17971,7 @@ mg_download(const char *host,
 			 *       2) here, ri.uri is the http response code */
 			conn->request_info.uri = conn->request_info.request_uri;
 #endif
-			conn->request_info.local_uri = conn->request_info.request_uri;
+			conn->request_info.local_uri = (char*)conn->request_info.request_uri;
 		}
 	}
 
@@ -18174,7 +18180,8 @@ mg_connect_websocket_client_impl(const struct mg_client_options *client_options,
 		mg_close_connection(conn);
 		return NULL;
 	}
-	conn->request_info.local_uri = conn->request_info.request_uri;
+	conn->request_info.local_uri_raw = conn->request_info.request_uri;
+	conn->request_info.local_uri = (char*)conn->request_info.local_uri_raw;
 
 #if defined(__clang__)
 #pragma clang diagnostic pop
@@ -18465,12 +18472,12 @@ process_new_connection(struct mg_connection *conn)
 			switch (uri_type) {
 			case 1:
 				/* Asterisk */
-				conn->request_info.local_uri = 0;
+				conn->request_info.local_uri_raw = 0;
 				/* TODO: Deal with '*'. */
 				break;
 			case 2:
 				/* relative uri */
-				conn->request_info.local_uri = conn->request_info.request_uri;
+				conn->request_info.local_uri_raw = conn->request_info.request_uri;
 				break;
 			case 3:
 			case 4:
@@ -18478,9 +18485,9 @@ process_new_connection(struct mg_connection *conn)
 				hostend = get_rel_url_at_current_server(
 				    conn->request_info.request_uri, conn);
 				if (hostend) {
-					conn->request_info.local_uri = hostend;
+					conn->request_info.local_uri_raw = hostend;
 				} else {
-					conn->request_info.local_uri = NULL;
+					conn->request_info.local_uri_raw = NULL;
 				}
 				break;
 			default:
@@ -18490,9 +18497,10 @@ process_new_connection(struct mg_connection *conn)
 				            sizeof(ebuf),
 				            "Invalid URI");
 				mg_send_http_error(conn, 400, "%s", ebuf);
-				conn->request_info.local_uri = NULL;
+				conn->request_info.local_uri_raw = NULL;
 				break;
 			}
+			conn->request_info.local_uri = (char*)conn->request_info.local_uri_raw;
 
 #if defined(MG_LEGACY_INTERFACE)
 			/* Legacy before split into local_uri and request_uri */
@@ -18981,11 +18989,11 @@ worker_thread_run(struct mg_connection *conn)
 	mg_free(conn->buf);
 	conn->buf = NULL;
 
-	/* Free local URI in raw form (if any) */
-	if(conn->request_info.local_uri_raw != NULL)
+	/* Free cleaned URI (if any) */
+	if(conn->request_info.local_uri != conn->request_info.local_uri_raw)
 	{
-		mg_free(conn->request_info.local_uri_raw);
-		conn->request_info.local_uri_raw = NULL;
+		mg_free(conn->request_info.local_uri);
+		conn->request_info.local_uri = NULL;
 	}
 
 #if defined(USE_SERVER_STATS)

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -14086,6 +14086,7 @@ handle_request(struct mg_connection *conn)
 
 	/* 1.4. clean URIs, so a path like allowed_dir/../forbidden_file is
 	 * not possible */
+	ri->local_uri_raw = mg_strdup(ri->local_uri);
 	remove_dot_segments((char *)ri->local_uri);
 
 	/* step 1. completed, the url is known now */
@@ -16816,6 +16817,13 @@ reset_per_request_attributes(struct mg_connection *conn)
 	conn->request_info.request_uri = NULL;
 	conn->request_info.local_uri = NULL;
 
+	/* Free local URI in raw form (if any) */
+	if(conn->request_info.local_uri_raw != NULL)
+	{
+		mg_free(conn->request_info.local_uri_raw);
+		conn->request_info.local_uri_raw = NULL;
+	}
+
 #if defined(MG_LEGACY_INTERFACE)
 	/* Legacy before split into local_uri and request_uri */
 	conn->request_info.uri = NULL;
@@ -18972,6 +18980,13 @@ worker_thread_run(struct mg_connection *conn)
 	conn->buf_size = 0;
 	mg_free(conn->buf);
 	conn->buf = NULL;
+
+	/* Free local URI in raw form (if any) */
+	if(conn->request_info.local_uri_raw != NULL)
+	{
+		mg_free(conn->request_info.local_uri_raw);
+		conn->request_info.local_uri_raw = NULL;
+	}
 
 #if defined(USE_SERVER_STATS)
 	conn->conn_state = 9; /* done */

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -11132,6 +11132,7 @@ prepare_cgi_environment(struct mg_connection *conn,
 
 	addenv(env, "REQUEST_URI=%s", conn->request_info.request_uri);
 	addenv(env, "LOCAL_URI=%s", conn->request_info.local_uri);
+	addenv(env, "LOCAL_URI_RAW=%s", conn->request_info.local_uri_raw);
 
 	/* SCRIPT_NAME */
 	uri_len = (int)strlen(conn->request_info.local_uri);

--- a/src/mod_lua.inl
+++ b/src/mod_lua.inl
@@ -2469,6 +2469,7 @@ prepare_lua_request_info(struct mg_connection *conn, lua_State *L)
 	reg_string(L, "request_method", conn->request_info.request_method);
 	reg_string(L, "request_uri", conn->request_info.request_uri);
 	reg_string(L, "uri", conn->request_info.local_uri);
+	reg_string(L, "uri_raw", conn->request_info.local_uri_raw);
 	reg_string(L, "http_version", conn->request_info.http_version);
 	reg_string(L, "query_string", conn->request_info.query_string);
 	reg_string(L, "remote_addr", conn->request_info.remote_addr);


### PR DESCRIPTION
This PR is the successor of #964 (check there for further details). TL;DR: We need a dedicated buffer containing the raw (local) URI sent by the requestor. This is currently overwritten by some cleaning routine inside `civetweb`.

Motivations for my changes:

The memory used for `local_uri` propagates downwards a rather long way. It is set in `mg_get_response` (which is an external interface and never used inside `civetweb.c`):
  https://github.com/civetweb/civetweb/blob/37300a0f09db4e6b64745d3b05ab5b2edc23497a/src/civetweb.c#L17910
  or in `process_new_connection` which is the relevant part for now:
  https://github.com/civetweb/civetweb/blob/37300a0f09db4e6b64745d3b05ab5b2edc23497a/src/civetweb.c#L18455-L18487
  The `request_uri` originates from
  https://github.com/civetweb/civetweb/blob/37300a0f09db4e6b64745d3b05ab5b2edc23497a/src/civetweb.c#L10695
  Where `buf` points to a part of memory containing the raw request:
  https://github.com/civetweb/civetweb/blob/37300a0f09db4e6b64745d3b05ab5b2edc23497a/src/civetweb.c#L18806

---

This shows that the function we're currently discussing about (`remove_dot_segments()`), modifies memory from the original request:
  https://github.com/civetweb/civetweb/blob/37300a0f09db4e6b64745d3b05ab5b2edc23497a/src/civetweb.c#L14087-L14089
  this seems counterintuitive as I'd expect the original `buf` to never get really modified at all.

Solution (`ri = conn->request_info` in the following): 

1. Instead of storing the snippet from the original `const char* buf` in `ri->local_uri`, we store it in `ri->local_uri_raw`, and
2. set `ri->local_uri = ri->local_uri_raw`.
2. Before calling the cleaning routine `remove_dot_segments()` (which used to wrongfully cast away the `const` attribute), we duplicate the memory in `ri->local_uri_raw` to have a dedicated buffer we can modify at will (which does not point to some memory inside `buf`).


Fixes #964 and #973