### PR TITLE
quick OpenSSL-3.0 API support

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -1555,8 +1555,8 @@ static int mg_openssl_initialized = 0;
 #if defined(OPENSSL_API_1_0) && defined(OPENSSL_API_1_1) && defined(OPENSSL_API_3_0)
 #error "Multiple OPENSSL_API versions defined"
 #endif
-#if (defined(OPENSSL_API_1_0) || defined(OPENSSL_API_1_1))                     \
-    || defined(OPENSSL_API_3_0) && defined(USE_MBEDTLS)
+#if (defined(OPENSSL_API_1_0) || defined(OPENSSL_API_1_1)                     \
+    || defined(OPENSSL_API_3_0)) && defined(USE_MBEDTLS)
 #error "Multiple SSL libraries defined"
 #endif
 #endif

--- a/src/openssl_dl.inl
+++ b/src/openssl_dl.inl
@@ -98,7 +98,7 @@ struct ssl_func {
 };
 
 
-#if defined(OPENSSL_API_1_1)
+#if defined(OPENSSL_API_1_1) || defined(OPENSSL_API_3_0)
 
 #define SSL_free (*(void (*)(SSL *))ssl_sw[0].ptr)
 #define SSL_accept (*(int (*)(SSL *))ssl_sw[1].ptr)
@@ -262,7 +262,11 @@ static struct ssl_func ssl_sw[] = {
     {"SSL_CTX_load_verify_locations", TLS_Mandatory, NULL},
     {"SSL_CTX_set_default_verify_paths", TLS_Mandatory, NULL},
     {"SSL_CTX_set_verify_depth", TLS_Mandatory, NULL},
+#if defined(OPENSSL_API_3_0)
+    {"SSL_get1_peer_certificate", TLS_Mandatory, NULL},
+#else
     {"SSL_get_peer_certificate", TLS_Mandatory, NULL},
+#endif
     {"SSL_get_version", TLS_Mandatory, NULL},
     {"SSL_get_current_cipher", TLS_Mandatory, NULL},
     {"SSL_CIPHER_get_name", TLS_Mandatory, NULL},


### PR DESCRIPTION
This is a quick PR to support compiling with OpenSSL 3.0.

It is unclear if you want more OPENSSL_API defines like this or if you want to unify the code for 1.1 and 3.0 support under a separate define (like for example OPENSSL_API_1_1_PLUS) so I've created this PR so you can see what it looks like.

At this stage this is just testing compilation and getting your feedback on the approach you want used.
