### PR TITLE
Bump minimum required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Determines what CMake APIs we can rely on
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 2.8.12)
 if (${CMAKE_VERSION} VERSION_GREATER 3.2.2)
   cmake_policy(VERSION 3.2.2)
 endif()


### PR DESCRIPTION
Hi,

Could the following simple change be reviewed please?

It will bump the minimum required CMake version to 2.8.12 now that it's released.

That will also avoid the following deprecation warning:

CMake Deprecation Warning at .../civetweb/CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

Thanks,
Gustavo