### PR TITLE
Mistyped function call in docs

### DIFF
--- a/docs/Embedding.md
+++ b/docs/Embedding.md
@@ -294,7 +294,7 @@ handler(struct mg_connection *conn, void *ignored)
 	const char *msg = "Hello world";
 	unsigned long len = (unsigned long)strlen(msg);
 
-    mg_send_ok(conn, "text/plain", len);
+	mg_send_http_ok(conn, "text/plain", len);
 
 	mg_write(conn, msg, len);
 


### PR DESCRIPTION
Found a mistyped function call in the example section of the Embedding doc.