### PR TITLE
Fix using NO_SSL_DL

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -16002,7 +16002,7 @@ initialize_openssl(char *ebuf, size_t ebuf_len)
 	}
 #endif /* NO_SSL_DL */
 
-#if defined(OPENSSL_API_1_1) || defined(OPENSSL_API_3_0)
+#if ( defined(OPENSSL_API_1_1) || defined(OPENSSL_API_3_0) ) && !defined(NO_SSL_DL)
 	/* Initialize SSL library */
 	OPENSSL_init_ssl(0, NULL);
 	OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS
@@ -16336,7 +16336,7 @@ init_ssl_ctx_impl(struct mg_context *phys_ctx,
 	int protocol_ver;
 	int ssl_cache_timeout;
 
-#if defined(OPENSSL_API_1_1) || defined(OPENSSL_API_3_0)
+#if ( defined(OPENSSL_API_1_1) || defined(OPENSSL_API_3_0) ) && !defined(NO_SSL_DL)
 	if ((dom_ctx->ssl_ctx = SSL_CTX_new(TLS_server_method())) == NULL) {
 		mg_cry_ctx_internal(phys_ctx,
 		                    "SSL_CTX_new (server) error: %s",
@@ -17150,7 +17150,7 @@ mg_connect_client_impl(const struct mg_client_options *client_options,
 	}
 
 #if !defined(NO_SSL) && !defined(USE_MBEDTLS) // TODO: mbedTLS client
-#if defined(OPENSSL_API_1_1) || defined(OPENSSL_API_3_0)
+#if ( defined(OPENSSL_API_1_1) || defined(OPENSSL_API_3_0) ) && !defined(NO_SSL_DL)
 	if (use_ssl
 	    && (conn->dom_ctx->ssl_ctx = SSL_CTX_new(TLS_client_method()))
 	           == NULL) {

--- a/src/openssl_dl.inl
+++ b/src/openssl_dl.inl
@@ -98,7 +98,7 @@ struct ssl_func {
 };
 
 
-#if defined(OPENSSL_API_1_1) || defined(OPENSSL_API_3_0)
+#if ( defined(OPENSSL_API_1_1) || defined(OPENSSL_API_3_0) ) && !defined(NO_SSL_DL)
 
 #define SSL_free (*(void (*)(SSL *))ssl_sw[0].ptr)
 #define SSL_accept (*(int (*)(SSL *))ssl_sw[1].ptr)


### PR DESCRIPTION
I had some problems using the NO_SSL_DL flag. Eventhough I was linking libcrypto in, then the code to load the library still was build.

I hope that I follow the conventions.

Solves: https://github.com/civetweb/civetweb/issues/1002
Signed-off-by: Kjeld Flarup <kfa@deif.com>
