### PR TITLE
missing definition of OPENSSL_REMOVE_THREAD_STATE if OpenSSL 3.x

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -1774,6 +1774,7 @@ typedef struct SSL_CTX SSL_CTX;
 #if !defined(OPENSSL_API_3_0)
 #define OPENSSL_API_3_0
 #endif
+#define OPENSSL_REMOVE_THREAD_STATE()
 #else
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
 #if !defined(OPENSSL_API_1_1)


### PR DESCRIPTION
The function `ERR_remove_thread_state()` is deprecated since OpenSSL 1.1.0, and corresponds to an empty function. The macro `OPENSSL_REMOVE_THREAD_STATE()` is defined in `civetweb.c` as a no-op macro for OpenSSL 1.1.x, but this definition is missing in the case of the newly-released OpenSSL 3.x family, which causes an undefined symbol error while linking civetweb. This pull request introduces the missing definition.