### PR TITLE
Fix static analysis findings

### DIFF
--- a/src/md5.inl
+++ b/src/md5.inl
@@ -285,8 +285,8 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
    a = b + ((a + F(b,c,d) + X[k] + T[i]) <<< s). */
 #define F(x, y, z) (((x) & (y)) | (~(x) & (z)))
 #define SET(a, b, c, d, k, s, Ti)                                              \
-	t = a + F(b, c, d) + X[k] + Ti;                                            \
-	a = ROTATE_LEFT(t, s) + b
+	t = (a) + F(b, c, d) + X[k] + (Ti);                                        \
+	(a) = ROTATE_LEFT(t, s) + (b)
 
 	/* Do the following 16 operations. */
 	SET(a, b, c, d, 0, 7, T1);
@@ -312,8 +312,8 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 	 a = b + ((a + G(b,c,d) + X[k] + T[i]) <<< s). */
 #define G(x, y, z) (((x) & (z)) | ((y) & ~(z)))
 #define SET(a, b, c, d, k, s, Ti)                                              \
-	t = a + G(b, c, d) + X[k] + Ti;                                            \
-	a = ROTATE_LEFT(t, s) + b
+	t = (a) + G(b, c, d) + X[k] + (Ti);                                        \
+	(a) = ROTATE_LEFT(t, s) + (b)
 
 	/* Do the following 16 operations. */
 	SET(a, b, c, d, 1, 5, T17);
@@ -339,8 +339,8 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 	 a = b + ((a + H(b,c,d) + X[k] + T[i]) <<< s). */
 #define H(x, y, z) ((x) ^ (y) ^ (z))
 #define SET(a, b, c, d, k, s, Ti)                                              \
-	t = a + H(b, c, d) + X[k] + Ti;                                            \
-	a = ROTATE_LEFT(t, s) + b
+	t = (a) + H(b, c, d) + X[k] + (Ti);                                        \
+	(a) = ROTATE_LEFT(t, s) + b
 
 	/* Do the following 16 operations. */
 	SET(a, b, c, d, 5, 4, T33);
@@ -366,8 +366,8 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 	 a = b + ((a + I(b,c,d) + X[k] + T[i]) <<< s). */
 #define I(x, y, z) ((y) ^ ((x) | ~(z)))
 #define SET(a, b, c, d, k, s, Ti)                                              \
-	t = a + I(b, c, d) + X[k] + Ti;                                            \
-	a = ROTATE_LEFT(t, s) + b
+	t = (a) + I(b, c, d) + X[k] + (Ti);                                        \
+	(a) = ROTATE_LEFT(t, s) + (b)
 
 	/* Do the following 16 operations. */
 	SET(a, b, c, d, 0, 6, T49);


### PR DESCRIPTION
We (devolo AG) have rather strict requirements about source code passing static analysis (among other things, we require a good deal of SEI CERT compliance). This PR eliminates the following findings:

```
civetweb/src/civetweb.c:5942:22: warning: pointer parameter 'stop_flag' can be pointer to const [readability-non-const-parameter]
civetweb/src/civetweb.c:6172:13: warning: 'atof' used to convert a string to a floating-point value, but function will not report conversion errors; consider using 'strtod' instead [cert-err34-c]
civetweb/src/civetweb.c:6440:13: warning: 'atof' used to convert a string to a floating-point value, but function will not report conversion errors; consider using 'strtod' instead [cert-err34-c]
civetweb/src/civetweb.c:10816:21: warning: 'atof' used to convert a string to a floating-point value, but function will not report conversion errors; consider using 'strtod' instead [cert-err34-c]
civetweb/src/civetweb.c:10819:7: warning: 'atof' used to convert a string to a floating-point value, but function will not report conversion errors; consider using 'strtod' instead [cert-err34-c]
civetweb/src/civetweb.c:10824:8: warning: 'atof' used to convert a string to a floating-point value, but function will not report conversion errors; consider using 'strtod' instead [cert-err34-c]
civetweb/src/civetweb.c:13264:19: warning: redundant cast to the same type [google-readability-casting]
civetweb/src/civetweb.c:13506:12: warning: redundant 'mg_construct_local_link' declaration [readability-redundant-declaration]
civetweb/src/civetweb.c:14068:2: warning: Value stored to 'uri_len' is never read [clang-analyzer-deadcode.DeadStores]
civetweb/src/civetweb.c:18110:40: warning: pointer parameter 'error_buffer' can be pointer to const [readability-non-const-parameter]
civetweb/src/md5.inl:288:6: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
civetweb/src/md5.inl:288:30: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
civetweb/src/md5.inl:289:2: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
civetweb/src/md5.inl:315:6: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
civetweb/src/md5.inl:315:30: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
civetweb/src/md5.inl:316:2: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
civetweb/src/md5.inl:342:6: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
civetweb/src/md5.inl:342:30: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
civetweb/src/md5.inl:343:2: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
civetweb/src/md5.inl:369:6: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
civetweb/src/md5.inl:369:30: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
civetweb/src/md5.inl:370:2: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
```

In addition, some uses of `sscanf` were flagged as `NOLINT` (=exclude from static analysis). Eventually these should also be reworked to use `strtol` or similar.

Static analysis was performed with clang-tidy 12.0.0.