### PR TITLE
CMake: fix installation of bundles on iOS/tvOS/watchOS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -263,9 +263,7 @@ if (CIVETWEB_ENABLE_SERVER_EXECUTABLE)
         install(
             TARGETS civetweb-c-executable
             EXPORT ${PROJECT_NAME}-targets
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            DESTINATION ${CMAKE_INSTALL_BINDIR}
             COMPONENT server)
     endif()
     target_include_directories(


### PR DESCRIPTION
If host is iOS, executables need a BUNDLE DESTINATION, otherwise CMale configuration fails. It's easier to set DESTINATION globally if all targets of install() command are executables.

see https://cmake.org/cmake/help/latest/policy/CMP0006.html