### PR TITLE
Fix for (null) in "Bad request" response

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -10637,11 +10637,6 @@ parse_http_request(char *buf, int len, struct mg_request_info *ri)
 		return -1;
 	}
 
-	/* Check for a valid http method */
-	if (!is_valid_http_method(ri->request_method)) {
-		return -1;
-	}
-
 	/* The second word is the URI */
 	ri->request_uri = buf;
 
@@ -10662,6 +10657,11 @@ parse_http_request(char *buf, int len, struct mg_request_info *ri)
 		return -1;
 	}
 	ri->http_version += 5;
+	
+	/* Check for a valid http method */
+	if (!is_valid_http_method(ri->request_method)) {
+		return -1;
+	}
 
 	/* Parse all HTTP headers */
 	ri->num_headers = parse_http_headers(&buf, ri->http_headers);


### PR DESCRIPTION
If a client sends a request that isn't handled (like 'PROPPATCH /example.c HTTP/1.1') then 'is_valid_http_method()' is called before the HTTP version is parsed which means the response sent to the client is malformed ('HTTP/(null) 400 Bad Request'), so call 'is_valid_http_method()' after parsing the HTTP version.

There is still the possibility for the client to send complete garbage (like 'GARBAGE') then the 'HTTP/(null)' still appears, for this scenario we probably need to set the version to a default (like '1.0'), not sure though.