### PR TITLE
Replace memset by value-initialization

### DIFF
--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -396,7 +396,6 @@ CivetServer::CivetServer(const char **options,
     : context(0)
 {
 	struct CivetCallbacks callbacks;
-	memset(&callbacks, 0, sizeof(callbacks));
 
 	UserContext = UserContextIn;
 
@@ -420,7 +419,6 @@ CivetServer::CivetServer(const std::vector<std::string> &options,
     : context(0)
 {
 	struct CivetCallbacks callbacks;
-	memset(&callbacks, 0, sizeof(callbacks));
 
 	UserContext = UserContextIn;
 


### PR DESCRIPTION
Otherwise I get the following warning:
```
'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct CivetCallbacks'
```

See: https://stackoverflow.com/questions/112085/is-this-c-structure-initialization-trick-safe