### PR TITLE
fix: FindWinSock include dir and library detection.

### DIFF
--- a/cmake/FindWinSock.cmake
+++ b/cmake/FindWinSock.cmake
@@ -39,6 +39,7 @@ endmacro(REMOVE_DUPLICATE_PATHS)
 
 set(WINSOCK_INCLUDE_PATHS "${WINSOCK_ROOT}/include/")
 if(MINGW)
+  file(TOUCH ${CMAKE_BINARY_DIR}/nul)
   execute_process(
     COMMAND ${CMAKE_C_COMPILER} -xc -E -v -
     RESULT_VARIABLE RESULT
@@ -71,7 +72,9 @@ if(MINGW)
   )
   if (NOT RESULT)
     string(REGEX MATCH "libraries: =([^\r\n]*)" OUT "${OUT}")
-    list(APPEND WINSOCK_LIBRARY_PATHS "${CMAKE_MATCH_1}")
+    string(REPLACE ":" ";" _WINSOCK_LIBRARY_PATH "${CMAKE_MATCH_1}")
+    list(APPEND WINSOCK_LIBRARY_PATHS "${_WINSOCK_LIBRARY_PATH}")
+    unset(_WINSOCK_LIBRARY_PATH)
   endif()
 endif()
 if ("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "AMD64" AND "${CMAKE_SIZEOF_VOID_P}" EQUAL 4)


### PR DESCRIPTION
1. `execute_process` with non-existing input file result "No such file" error which can't be parsed
2. `WINSOCK_LIBRARY_PATHS` replace : with ; to make it valid list

I'm trying to add civetweb as a package to [xmake-repo](https://github.com/xmake-io/xmake-repo/pull/997). Github action for that PR fails for compiling civetweb using mingw. The [link error](https://github.com/xmake-io/xmake-repo/runs/5153898783?check_suite_focus=true#step:5:36) can be fixed with this fix.

Note it's still not very reliable to find the correct include directory and library file path for winsock2 when using MinGW. But I'm not able to investigate further because limited experience with MinGW.