### PR TITLE
Replace usage of localtime with localtime_r in log_access when built with REENTRANT_TIME

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -15923,7 +15923,12 @@ log_access(const struct mg_connection *conn)
 	const struct mg_request_info *ri;
 	struct mg_file fi;
 	char date[64], src_addr[IP_ADDR_STR_LEN];
+#if defined(REENTRANT_TIME)
+	struct tm _tm;
+	struct tm *tm = &_tm;
+#else
 	struct tm *tm;
+#endif
 
 	const char *referer;
 	const char *user_agent;
@@ -16001,7 +16006,11 @@ log_access(const struct mg_connection *conn)
 
 	/* If we did not get a log message from Lua, create it here. */
 	if (!log_buf[0]) {
+#if defined(REENTRANT_TIME)
+		localtime_r(&conn->conn_birth_time, tm);
+#else
 		tm = localtime(&conn->conn_birth_time);
+#endif
 		if (tm != NULL) {
 			strftime(date, sizeof(date), "%d/%b/%Y:%H:%M:%S %z", tm);
 		} else {


### PR DESCRIPTION
The `log_access` function uses the thread unsafe function `localtime`, replace with the re-entrant `localtime_r` when the `REENTRANT_TIME` flag is defined.