### PR TITLE
Using higher-level wrapper of OpenSSL SHA1 hash function

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -12991,7 +12991,6 @@ send_websocket_handshake(struct mg_connection *conn, const char *websock_key)
 	static const char *magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 	char buf[100], sha[20], b64_sha[sizeof(sha) * 2];
 	size_t dst_len = sizeof(b64_sha);
-	SHA_CTX sha_ctx;
 	int truncated;
 
 	/* Calculate Sec-WebSocket-Accept reply from Sec-WebSocket-Key. */
@@ -13003,9 +13002,8 @@ send_websocket_handshake(struct mg_connection *conn, const char *websock_key)
 
 	DEBUG_TRACE("%s", "Send websocket handshake");
 
-	SHA1_Init(&sha_ctx);
-	SHA1_Update(&sha_ctx, (unsigned char *)buf, (uint32_t)strlen(buf));
-	SHA1_Final((unsigned char *)sha, &sha_ctx);
+	EVP_Digest((unsigned char *)buf, (uint32_t)strlen(buf), (unsigned char *)sha,
+		NULL, EVP_get_digestbyname("sha1"), NULL);
 	mg_base64_encode((unsigned char *)sha, sizeof(sha), b64_sha, &dst_len);
 	mg_printf(conn,
 	          "HTTP/1.1 101 Switching Protocols\r\n"


### PR DESCRIPTION
This is to get rid of deprecation warninigs when building with newer
OpenSSL versions:
https://www.openssl.org/docs/manmaster/man3/SHA1_Init.html