### PR TITLE
types warning

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -1353,7 +1353,7 @@ CIVETWEB_API int mg_base64_encode(const unsigned char *src,
    returns -1 on OK. */
 CIVETWEB_API int mg_base64_decode(const char *src,
                                   size_t src_len,
-                                  unsigned char *dst,
+                                  char *dst,
                                   size_t *dst_len);
 
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -7326,7 +7326,7 @@ b64reverse(char letter)
 CIVETWEB_API int
 mg_base64_decode(const char *src,
                  size_t src_len,
-                 unsigned char *dst,
+                 char *dst,
                  size_t *dst_len)
 {
 	size_t i;


### PR DESCRIPTION
'char *' to parameter of type 'unsigned char *' converts between pointers to integer types

```cpp
CIVETWEB_API int mg_base64_decode(const char *src,
                                  size_t src_len,
                                  unsigned char *dst, 
                                  size_t *dst_len);

char *buf;
mg_base64_decode(userpw_b64, userpw_b64_len, buf, &buf_len_r);
```