### PR TITLE
zephyr: update include paths to use <zephyr/...>

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -195,7 +195,7 @@ mg_static_assert(sizeof(void *) >= sizeof(int), "data type size check");
 #include <sys/socket.h>
 #include <time.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 /* Max worker threads is the max of pthreads minus the main application thread
  * and minus the main civetweb thread, thus -2

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -195,7 +195,7 @@ mg_static_assert(sizeof(void *) >= sizeof(int), "data type size check");
 #include <sys/socket.h>
 #include <time.h>
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 /* Max worker threads is the max of pthreads minus the main application thread
  * and minus the main civetweb thread, thus -2


### PR DESCRIPTION
Zephyr has prefixed all of its includes with <zephyr/...>. While the old
mode can still be used (CONFIG_LEGACY_INCLUDE_PATH) and is still enabled
by default, it's better to be prepared for its removal in the future.