### PR TITLE
Use EVP_Digest only with OpenSSL 3.0

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -12981,8 +12981,10 @@ mg_unlock_context(struct mg_context *ctx)
 #if defined(USE_WEBSOCKET)
 
 #if !defined(NO_SSL_DL)
+#if !defined(OPENSSL_API_3_0)
 #define SHA_API static
 #include "sha1.inl"
+#endif
 #endif
 
 static int
@@ -12991,6 +12993,9 @@ send_websocket_handshake(struct mg_connection *conn, const char *websock_key)
 	static const char *magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 	char buf[100], sha[20], b64_sha[sizeof(sha) * 2];
 	size_t dst_len = sizeof(b64_sha);
+#if !defined(OPENSSL_API_3_0)
+   SHA_CTX sha_ctx;
+#endif
 	int truncated;
 
 	/* Calculate Sec-WebSocket-Accept reply from Sec-WebSocket-Key. */
@@ -13002,8 +13007,14 @@ send_websocket_handshake(struct mg_connection *conn, const char *websock_key)
 
 	DEBUG_TRACE("%s", "Send websocket handshake");
 
+#if defined(OPENSSL_API_3_0)
 	EVP_Digest((unsigned char *)buf, (uint32_t)strlen(buf), (unsigned char *)sha,
 		NULL, EVP_get_digestbyname("sha1"), NULL);
+#else
+   SHA1_Init(&sha_ctx);
+   SHA1_Update(&sha_ctx, (unsigned char *)buf, (uint32_t)strlen(buf));
+   SHA1_Final((unsigned char *)sha, &sha_ctx);
+#endif
 	mg_base64_encode((unsigned char *)sha, sizeof(sha), b64_sha, &dst_len);
 	mg_printf(conn,
 	          "HTTP/1.1 101 Switching Protocols\r\n"
@@ -22221,12 +22232,12 @@ mg_get_handler_info(struct mg_context *ctx,
     mg_lock_context(ctx);
 
     for (tmp_rh = ctx->dd.handlers; tmp_rh != NULL; tmp_rh = tmp_rh->next) {
-                
+
         if (buflen > handler_info_len+ tmp_rh->uri_len) {
         memcpy(buffer+handler_info_len, tmp_rh->uri, tmp_rh->uri_len);
         }
         handler_info_len += tmp_rh->uri_len;
-        
+
         switch (tmp_rh->handler_type) {
             case REQUEST_HANDLER:
                 (void)tmp_rh->handler;
@@ -22235,12 +22246,12 @@ mg_get_handler_info(struct mg_context *ctx,
         (void)tmp_rh->connect_handler;
        (void) tmp_rh->ready_handler;
        (void) tmp_rh->data_handler;
-       (void) tmp_rh->close_handler; 
+       (void) tmp_rh->close_handler;
             break;
             case AUTH_HANDLER:
-             (void) tmp_rh->auth_handler; 
+             (void) tmp_rh->auth_handler;
             break;
-        }      
+        }
         (void)cbdata;
     }
 


### PR DESCRIPTION
Only starting from this SSL version one get deprecation warnings.

    SHA1_Init’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]

But one still can use old SHA methods with older SSL and with
systems without SSL at all