### PR TITLE
Remove unused variables mlen, uri_len

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -14618,7 +14618,7 @@ handle_request(struct mg_connection *conn)
 {
 	struct mg_request_info *ri = &conn->request_info;
 	char path[UTF8_PATH_MAX];
-	int uri_len, ssl_index;
+	int ssl_index;
 	int is_found = 0, is_script_resource = 0, is_websocket_request = 0,
 	    is_put_or_delete_request = 0, is_callback_resource = 0,
 	    is_template_text_file = 0, is_webdav_request = 0;
@@ -14671,7 +14671,6 @@ handle_request(struct mg_connection *conn)
 		}
 		return;
 	}
-	uri_len = (int)strlen(ri->local_uri);
 
 	/* 1.3. decode url (if config says so) */
 	if (should_decode_url(conn)) {


### PR DESCRIPTION
Remove unused variables that are set with no visible side effect.

/usr/bin/clang-14 -Wall -Wextra -Werror -Wshadow -Wno-sign-compare -Wno-pragmas -Wno-tautological-pointer-compare
Results in 
civetweb/src/civetweb.c:8769:12: error: unused variable 'mlen' [-Werror,-Wunused-variable]
                                size_t mlen = strlen(workdata->f_user)
                                       ^
civetweb/src/civetweb.c:14621:6: error: variable 'uri_len' set but not used [-Werror,-Wunused-but-set-variable]
        int uri_len, ssl_index;