### PR TITLE
Revert "Remove unused variables mlen, uri_len"

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -14629,7 +14629,7 @@ handle_request(struct mg_connection *conn)
 {
 	struct mg_request_info *ri = &conn->request_info;
 	char path[UTF8_PATH_MAX];
-	int ssl_index;
+	int uri_len, ssl_index;
 	int is_found = 0, is_script_resource = 0, is_websocket_request = 0,
 	    is_put_or_delete_request = 0, is_callback_resource = 0,
 	    is_template_text_file = 0, is_webdav_request = 0;
@@ -14682,6 +14682,7 @@ handle_request(struct mg_connection *conn)
 		}
 		return;
 	}
+	uri_len = (int)strlen(ri->local_uri);
 
 	/* 1.3. decode url (if config says so) */
 	if (should_decode_url(conn)) {


### PR DESCRIPTION
Reverts civetweb/civetweb#1082

Variables are required for some #ifdef combinations.
These must be used as condition for removing the used/unused variables again.