### PR TITLE
Fix broken API documentation link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ Documentation
 - [Building.md](Building.md) - Building the Server (quick start guide)
 - [Embedding.md](Embedding.md) - Embedding (how to add HTTP support to an existing application)
 - [OpenSSL.md](OpenSSL.md) - Adding HTTPS (SSL/TLS) support using OpenSSL.
-- [API documentation](api) - Additional documentation on the civetweb application programming interface ([civetweb.h](https://github.com/civetweb/civetweb/blob/master/include/civetweb.h)).
+- [APIReference.md](APIReference.md) - Additional documentation on the civetweb application programming interface ([civetweb.h](https://github.com/civetweb/civetweb/blob/master/include/civetweb.h)).
 
 [Authors](https://github.com/civetweb/civetweb/blob/master/CREDITS.md)
 


### PR DESCRIPTION
 at http://civetweb.github.io/civetweb/