### PR TITLE
feat: duplicate get requets data

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -1045,6 +1045,8 @@ CIVETWEB_API long long mg_store_body(struct mg_connection *conn,
      > 0   number of bytes read into the buffer. */
 CIVETWEB_API int mg_read(struct mg_connection *, void *buf, size_t len);
 
+CIVETWEB_API void mg_read_done(struct mg_connection *);
+
 
 /* Get the value of particular HTTP header.
 

--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -448,7 +448,7 @@ CivetServer::CivetServer(const std::vector<std::string> &options,
 	for (size_t i = 0; i < options.size(); i++) {
 		pointers[i] = (options[i].c_str());
 	}
-	pointers.back() = NULL;	
+	pointers.back() = NULL;
 
 	struct mg_init_data mg_start_init_data = {0};
 	mg_start_init_data.callbacks = &callbacks;
@@ -718,6 +718,7 @@ CivetServer::getPostData(struct mg_connection *conn)
 		postdata.append(buf, r);
 		r = mg_read(conn, buf, sizeof(buf));
 	}
+	mg_read_done(conn);
 	mg_unlock_connection(conn);
 	return postdata;
 }

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -6722,6 +6722,15 @@ mg_read(struct mg_connection *conn, void *buf, size_t len)
 }
 
 
+CIVETWEB_API void 
+mg_read_done(struct mg_connection *conn) 
+{
+      if (conn == NULL) {
+         	return;
+      }
+      conn->consumed_content = 0;
+}
+
 CIVETWEB_API int
 mg_write(struct mg_connection *conn, const void *buf, size_t len)
 {


### PR DESCRIPTION
### System information
- **OS Platform and Distribution**: Ubuntu and macOS
- **programing language**: Cpp CivetServer

### Description
- Post request using HTTP service
- Get request data through `CivetServer::getPostData()`
- Data can be acquired for the first time, but the data acquired for the second time is empty
```
// civetweb/examples/embedded_cpp/embedded_cpp.cpp:115:2
handlePost(CivetServer *server, struct mg_connection *conn)
{
              std::string data1 = CivetServer::getPostData(conn);
              std::cout << "data1:" << data1 << std::endl; // ok 
              std::string data2 = CivetServer::getPostData(conn);
              std::cout << "data2:" << data2 << std::endl; // data is empty 
              return handleAll("POST", server, conn);
}
```

### Solution
- After reading data from `CivetServer::getPostData()`, set conn->consumed_content to 0

**The above is my solution to this problem. Does `civetweb` have a solution to this problem?**

