### PR TITLE
Use bash for pipefail in build script

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 


### PR DESCRIPTION
For systems where `sh` is not `bash`. Mentioned here earlier https://github.com/civetweb/civetweb/issues/200#issuecomment-142498907.