### PR TITLE
Fix compilation warning when USE_X_DOM_SOCKET is defined

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -3328,7 +3328,7 @@ sockaddr_to_string(char *buf, size_t len, const union usa *usa)
 		NI_NUMERICHOST);
 		*/
 		strncpy(buf, UNIX_DOMAIN_SOCKET_SERVER_NAME, len);
-		buf[len] = 0;
+		buf[len-1] = 0;
 	}
 #endif
 }


### PR DESCRIPTION
When unix socket is enabled, one gets several warnings like:

```
In function ‘sockaddr_to_string’,
    inlined from ‘sockaddr_to_string’ at civetweb.c:3255:1,
    inlined from ‘mg_cry_internal_impl.constprop’ at civetweb.c:3403:4:
civetweb.c:3296:26: warning: array subscript 50 is outside array bounds of ‘char[50]’ [-Warray-bounds]
 3296 |                 buf[len] = 0;
```

It should be `buf[len-1] = 0;`