### PR TITLE
Fix codespell issues

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -524,7 +524,7 @@ Changes
 - Added new C++ abstraction class CivetServer
 - Added thread safety for and fixed websocket defects (Morgan McGuire)
 - Created PKGBUILD to use Arch distribution (Daniel Oaks)
-- Created new documentation on Embeddeding, Building and yaSSL (see docs/).
+- Created new documentation on Embedding, Building and yaSSL (see docs/).
 - Updated License file to include all licenses.
 - Replaced MD5 implementation due to questionable license.
      + This requires new source file md5.inl
@@ -547,7 +547,7 @@ Known Issues
 - Build support for VS6 and some other has been deprecated.
     + This does not impact embedded programs, just the stand-alone build.
     + The old Makefile was renamed to Makefile.deprecated.
-    + This is partcially do to lack fo testing.
+    + This is partcially do to lack of testing.
     + Need to find out what is actually in demand.
 - Build changes may impact current users.
     + As with any change of this type, changes may impact some users.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ Selected, critical defects are fixed in the latest release as well.
 
 Note that different security policies apply to different files/folders in this project:
 - The core components are include/civetweb.h, src/civetweb.c and src/*.inl.  These files are part of every server instance in production. Therefore they have to undergo the most intensive security tests and reviews.
-- The src/main.c file is used by the standalone server. It is used in various tests in combination with the aforementioned core components. Aplications embedding civetweb will not use main.c and, thus, do not suffer from any vulnerabilities therein.
+- The src/main.c file is used by the standalone server. It is used in various tests in combination with the aforementioned core components. Applications embedding civetweb will not use main.c and, thus, do not suffer from any vulnerabilities therein.
 - The example folders contain different usage examples in different maintenance state. This is explained in detail in the README file there.
 - The content of all test folders (test, unittest, fuzztest) is used to test the server functionality. These tests are not designed with security in mind - on the contrary, some tests contain scripts or settings that even introduce security leaks on purpose. All tests are only meant to be run in a test environment. You should not use the content of any test folder in production. Also certificates in "resources/cert" are only meant to be used in test environments and must never be used in production.
 

--- a/build.cmd
+++ b/build.cmd
@@ -124,7 +124,7 @@
              build ^
              install
 @for %%m in (%methods%) do @(
-  call :log 3 "Excuting the '%%m' method"
+  call :log 3 "Executing the '%%m' method"
   call :log 8
   call :%%~m
   if errorlevel 1 (
@@ -400,9 +400,9 @@
 @endlocal & set "%var%=%file_path%"
 @goto :eof
 
-:administrator_check - Checks for administrator priviledges
+:administrator_check - Checks for administrator privileges
 @setlocal
-@call :log 2 "Checking for administrator priviledges"
+@call :log 2 "Checking for administrator privileges"
 @set "key=HKLM\Software\VCA\Tool Chain\Admin Check"
 @reg add "%key%" /v Elevated /t REG_DWORD /d 1 /f > nul 2>&1
 @if errorlevel 1 exit /b 1

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -163,7 +163,7 @@ make build COPT="-DNDEBUG -DNO_CGI"
 |                              |                                                                     |
 | `USE_ALPN`                   | enable Application-Level-Protocol-Negotiation, required for HTTP2   |
 | `USE_DUKTAPE`                | enable server-side JavaScript (using Duktape library)               |
-| `USE_HTTP2`                  | enable HTTP2 support (experimental, not reccomended for production) |
+| `USE_HTTP2`                  | enable HTTP2 support (experimental, not recommended for production) |
 | `USE_IPV6`                   | enable IPv6 support                                                 |
 | `USE_LUA`                    | enable Lua support                                                  |
 | `USE_SERVER_STATS`           | enable server statistics support                                    |

--- a/docs/Contribution.md
+++ b/docs/Contribution.md
@@ -7,7 +7,7 @@ Contributions to CivetWeb are welcome, provided all contributions carry the MIT 
 - If you know how to fix the issue, please create a pull request on GitHub. Please take care your modifications pass the continuous integration checks. These checks are performed automatically when you create a pull request, but it may take some hours until all tests are completed. Please provide a description for every pull request (see below).
 - Alternatively, you can post a patch or describe the required modifications in a GitHub issue. However, a pull request would be preferred.
 
-- Improvments to documentation, tests and examples are welcome as well.
+- Improvements to documentation, tests and examples are welcome as well.
 
 - Contributor names are listed in [CREDITS.md](https://github.com/civetweb/civetweb/blob/master/CREDITS.md), unless you explicitly state you don't want your name to be listed there. This file is occasionally updated, adding new contributors, using author names from git commits and GitHub comments.
 

--- a/docs/Embedding.md
+++ b/docs/Embedding.md
@@ -3,7 +3,7 @@ Embedding CivetWeb
 
 CivetWeb is primarily designed so applications can easily add HTTP and HTTPS server as well as WebSocket (WS and WSS) server functionality.
 For example, a C/C++ application could use CivetWeb to enable a web service and configuration interface, to add a HTML5 data visualization interface, for automation or remote control, as a protocol gateway or as a HTTP/WebSocket client for firewall traversal.
-Often the easiest way to embedd CivetWeb is to add the civetweb.c file into your existing C project (see below).
+Often the easiest way to embed CivetWeb is to add the civetweb.c file into your existing C project (see below).
 
 CivetWeb can also be used as a stand-alone executable. It can deliver static files and offers built-in server side Lua, JavaScript and CGI support. Some instructions how to build the stand-alone server can be found in [Building.md](https://github.com/civetweb/civetweb/blob/master/docs/Building.md).
 

--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -8,7 +8,7 @@ The latest source code version is available at [https://github.com/civetweb/cive
 Windows
 ---
 
-This pre-built version comes pre-built wit Lua support. Libraries for SSL support are not included due to licensing restrictions;
+This pre-built version comes pre-built with Lua support. Libraries for SSL support are not included due to licensing restrictions;
 however, users may add an SSL library themselves.
 Instructions for adding SSL support can be found in [https://github.com/civetweb/civetweb/tree/master/docs](https://github.com/civetweb/civetweb/tree/master/docs)
 

--- a/docs/UserManual.md
+++ b/docs/UserManual.md
@@ -102,7 +102,7 @@ All other characters in the pattern match themselves. Examples:
     **.cgi$          Any string that ends with .cgi
     /foo             Any string that begins with /foo
     **a$|**b$        Any string that ends with a or b
-    
+
     /data/????.css$  Matches css files with 4 letter names in "/data" folder.
     /data/*.js$      Matches all js file names in "/data" folder.
     /api/*/*.cgi$    Matches "/api/resourcetype/resourcename.cgi"
@@ -150,7 +150,7 @@ See the [Wikipedia page on CORS](http://en.wikipedia.org/wiki/Cross-origin_resou
 An Access Control List (ACL) allows restrictions to be put on the list of IP
 addresses which have access to the web server. In the case of the CivetWeb
 web server, the ACL is a comma separated list of IP subnets, where each
-subnet is pre-pended by either a `-` or a `+` sign. A plus sign means allow,
+subnet is prepended by either a `-` or a `+` sign. A plus sign means allow,
 where a minus sign means deny. If a subnet mask is omitted, such as `-1.2.3.4`,
 this means to deny only that single IP address.
 
@@ -438,7 +438,7 @@ SSL port. For example, if `listening_ports` is `80r,443s`, then all
 HTTP traffic coming at port 80 will be redirected to HTTPS port 443.
 
 It is possible to specify an IP address to bind to. In this case,
-an IP address and a colon must be pre-pended to the port number.
+an IP address and a colon must be prepended to the port number.
 For example, to bind to a loopback interface on port 80 and to
 all interfaces on HTTPS port 443, use `127.0.0.1:80,443s`.
 
@@ -688,7 +688,7 @@ TLS1.1+TLS1.2+TLS1.3 | 3
 TLS1.2+TLS1.3 | 4
 TLS1.3 | 5
 
-TLS version 1.3 is only available if you are using an up-to-date TLS libary.
+TLS version 1.3 is only available if you are using an up-to-date TLS library.
 The default setting has been changed from 0 to 4 in CivetWeb 1.14.
 
 ### ssl\_short\_trust `no`
@@ -977,8 +977,8 @@ mg (table):
     mg.get_mime_type(filename)  -- get MIME type of a file
     mg.get_option(name)         -- get configuration option value from name
     mg.get_response_code_text(n)-- get response code text for n, nil otherwise
-    mg.get_var(str, varname, [occurance])  -- extract the first occurance of variable from (query) string
-                                --     otherwise the nth occurance if supplied, nil if not found
+    mg.get_var(str, varname, [occurrence])  -- extract the first occurrence of variable from (query) string
+                                --     otherwise the nth occurrence if supplied, nil if not found
     mg.send_file(filename)      -- send a file, including all required HTTP headers
     mg.send_file_body(filename) -- send a file, excluding HTTP headers
     mg.send_http_error(n,str)   -- send http error code n with string body
@@ -1017,7 +1017,7 @@ mg (table):
          .https                 -- true if accessed by https://, false otherwise
          .remote_user           -- user name if authenticated, nil otherwise
          .auth_type             -- Digest
-         .client_cert           -- Table with ssl certificate infomation
+         .client_cert           -- Table with ssl certificate information
               .subject          -- Certificate subject
               .issuer           -- Certificate issuer
               .serial           -- Certificate serial number
@@ -1125,7 +1125,7 @@ some features of the "mg" library are not available yet. Use the "start()" callb
 function instead.
 
 A Lua background script may define the following functions:
-    `start()`        -- called wnen the server is started
+    `start()`        -- called when the server is started
     `stop()`         -- called when the server is stopped
     `log(req, res)`  -- called when an access log entry is created
 

--- a/docs/api/mg_callbacks.md
+++ b/docs/api/mg_callbacks.md
@@ -19,7 +19,7 @@
 |**`http_error`**|**`int (*http_error)( struct mg_connection *conn, int status, const char *msg );`**|
 | |The callback function `http_error()` is called by CivetWeb just before an HTTP error is to be sent to the client. The function allows the application to send a custom error page. The status code of the error is provided as a parameter. If the application sends their own error page, it must return 0 to signal CivetWeb that no further processing is needed. If the returned value is not 0, CivetWeb will send an error page to the client.|
 |**`init_context`**|**`void (*init_context)( const struct mg_context *ctx );`**|
-| |The callback function `init_context()` is called after the CivetWeb server has been started and initialized, but before any requests are served. This allowes the application to perform some initialization activities before the first requests are handled.|
+| |The callback function `init_context()` is called after the CivetWeb server has been started and initialized, but before any requests are served. This allows the application to perform some initialization activities before the first requests are handled.|
 |**`init_lua`**|**`void (*init_lua)( const struct mg_connection *conn, void *lua_context, unsigned context_flags );`**|
 | |The callback function `init_lua()` is called just before a Lua server page is to be served. Lua page serving must have been enabled at compile time for this callback function to be called. The parameter `lua_context` is a `lua_State *` pointer. The parameter `context_flags` indicate the type of Lua environment. |
 |**`exit_lua`**|**`void (*init_lua)( const struct mg_connection *conn, void *lua_context, unsigned context_flags );`**|

--- a/docs/api/mg_check_feature.md
+++ b/docs/api/mg_check_feature.md
@@ -31,7 +31,7 @@ The following parameter values can be used:
 | **64** | USE_DUKTAPE | *Support for server side JavaScript*. Server side JavaScript can be used for dynamic page generation if the proper options have been set at compile time. Please note that client side JavaScript execution is always available if it has been enabled in the connecting browser. |
 | **128** | NO_CACHING | *Support for caching*. The webserver will support caching, if it has not been disabled while compiling the library. |
 
-Parameter values other than the values mentioned above will give undefined results. Therefore&mdash;although the parameter values for the `mg_check_feature()` function are effectively bitmasks, you should't assume that combining two of those values with an OR to a new value will give any meaningful results when the function returns.
+Parameter values other than the values mentioned above will give undefined results. Therefore&mdash;although the parameter values for the `mg_check_feature()` function are effectively bitmasks, you shouldn't assume that combining two of those values with an OR to a new value will give any meaningful results when the function returns.
 
 ### See Also
 

--- a/docs/api/mg_get_user_connection_data.md
+++ b/docs/api/mg_get_user_connection_data.md
@@ -16,7 +16,7 @@
 
 ### Description
 
-The function `mg_get_user_connection_data()` returns the user data associated with a connection. This user data is represented with a pointer which has been prevously registered with a call to [`mg_set_user_connection_data();`](mg_set_user_connection_data.md). With this function it is possible to pass state information between callback functions referring to a specific connection.
+The function `mg_get_user_connection_data()` returns the user data associated with a connection. This user data is represented with a pointer which has been previously registered with a call to [`mg_set_user_connection_data();`](mg_set_user_connection_data.md). With this function it is possible to pass state information between callback functions referring to a specific connection.
 
 ### See Also
 

--- a/docs/api/mg_md5.md
+++ b/docs/api/mg_md5.md
@@ -17,7 +17,7 @@
 
 ### Description
 
-The function `mg_md5()` caluclates the MD5 checksum of a NULL terminated list of NUL terminated ASCII strings. The MD5 checksum is returned in human readable format as an MD5 string in a caller supplied buffer.
+The function `mg_md5()` calculates the MD5 checksum of a NULL terminated list of NUL terminated ASCII strings. The MD5 checksum is returned in human readable format as an MD5 string in a caller supplied buffer.
 
 The function returns a pointer to the supplied result buffer.
 

--- a/docs/api/mg_modify_passwords_file.md
+++ b/docs/api/mg_modify_passwords_file.md
@@ -21,7 +21,7 @@
 
 The function `mg_modify_passwords_file()` allows an application to manipulate .htpasswd files on the fly by adding, deleting and changing user records. This is one of the several ways to implement authentication on the server side.
 
-If the password parameter is not `NULL` an entry is added to the password file. An existing records is modified in that case. If `NULL` is used as the password the enrty is removed from the file.
+If the password parameter is not `NULL` an entry is added to the password file. An existing records is modified in that case. If `NULL` is used as the password the entry is removed from the file.
 
 The function returns 1 when successful and 0 if an error occurs.
 

--- a/docs/yaSSL.md
+++ b/docs/yaSSL.md
@@ -15,7 +15,7 @@ Getting Started
 
 - Download Cayssl at https://www.wolfssl.com (formerly http://www.yassl.com/)
 - Extract the zip file
-    - To make this seemless, extract to a directory parallel to with Civetweb is
+    - To make this seamless, extract to a directory parallel to with Civetweb is
 
 ### Example Project
 

--- a/examples/embedded_c/embedded_c.c
+++ b/examples/embedded_c/embedded_c.c
@@ -4,7 +4,7 @@
  * License http://opensource.org/licenses/mit-license.php MIT License
  */
 
-/* Note: This example ommits some error checking and input validation for a
+/* Note: This example omits some error checking and input validation for a
  * better clarity/readability of the code. Example codes undergo less quality
  * management than the main source files of this project. */
 

--- a/examples/rest/cJSON/cJSON.c
+++ b/examples/rest/cJSON/cJSON.c
@@ -126,7 +126,7 @@ typedef struct internal_hooks
 } internal_hooks;
 
 #if defined(_MSC_VER)
-/* work around MSVC error C2322: '...' address of dillimport '...' is not static */
+/* work around MSVC error C2322: '...' address of dllimport '...' is not static */
 static void *internal_malloc(size_t size)
 {
     return malloc(size);
@@ -505,7 +505,7 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
         }
     }
 
-    /* sprintf failed or buffer overrun occured */
+    /* sprintf failed or buffer overrun occurred */
     if ((length < 0) || (length > (int)(sizeof(number_buffer) - 1)))
     {
         return false;
@@ -1556,7 +1556,7 @@ static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_bu
         buffer_skip_whitespace(input_buffer);
         if (!parse_string(current_item, input_buffer))
         {
-            goto fail; /* faile to parse name */
+            goto fail; /* failed to parse name */
         }
         buffer_skip_whitespace(input_buffer);
 

--- a/examples/rest/cJSON/cJSON.h
+++ b/examples/rest/cJSON/cJSON.h
@@ -195,7 +195,7 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateObject(void);
 /* Create a string where valuestring references a string so
  * it will not be freed by cJSON_Delete */
 CJSON_PUBLIC(cJSON *) cJSON_CreateStringReference(const char *string);
-/* Create an object/arrray that only references it's elements so
+/* Create an object/array that only references it's elements so
  * they will not be freed by cJSON_Delete */
 CJSON_PUBLIC(cJSON *) cJSON_CreateObjectReference(const cJSON *child);
 CJSON_PUBLIC(cJSON *) cJSON_CreateArrayReference(const cJSON *child);
@@ -217,7 +217,7 @@ CJSON_PUBLIC(void) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJ
 CJSON_PUBLIC(void) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item);
 CJSON_PUBLIC(void) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item);
 
-/* Remove/Detatch items from Arrays/Objects. */
+/* Remove/Detach items from Arrays/Objects. */
 CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item);
 CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromArray(cJSON *array, int which);
 CJSON_PUBLIC(void) cJSON_DeleteItemFromArray(cJSON *array, int which);

--- a/examples/rest/rest.c
+++ b/examples/rest/rest.c
@@ -41,7 +41,7 @@ SendJSON(struct mg_connection *conn, cJSON *json_obj)
 	mg_write(conn, json_str, json_str_len);
 
 	/* Add a newline. This is not required, but the result is more
-	 * human-readable in a debuger. */
+	 * human-readable in a debugger. */
 	mg_write(conn, "\n", 1);
 
 	/* Free string allocated by cJSON_Print* */
@@ -213,7 +213,7 @@ ExampleHandler(struct mg_connection *conn, void *cbdata)
 	if ((ret != url_len) || (mcx.num_matches != 2)) {
 		/* Note: Could have done this with a $ at the end of the match
 		 * pattern as well. Then we would have to check for a return value
-		 * of -1 only. Here we use this version as minumum modification
+		 * of -1 only. Here we use this version as minimum modification
 		 * of the existing code. */
 		printf("Match ret: %i\n", (int)ret);
 		mg_send_http_error(conn, 404, "Invalid path: %s\n", url);

--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -654,7 +654,7 @@ CIVETWEB_API void *mg_get_thread_pointer(const struct mg_connection *conn);
    or write to the connection. */
 /* Note: An alternative is to use the init_connection callback
    instead to initialize the user connection data pointer. It is
-   reccomended to supply a pointer to some user defined data structure
+   recommended to supply a pointer to some user defined data structure
    as conn_data initializer in init_connection. In case it is required
    to change some data after the init_connection call, store another
    data pointer in the user defined data structure and modify that
@@ -1128,7 +1128,7 @@ CIVETWEB_API int mg_get_var2(const char *data,
    required to increase this value at compile time.
 
    Parameters:
-     data: form encoded iput string. Will be modified by this function.
+     data: form encoded input string. Will be modified by this function.
      form_fields: output list of name/value-pairs. A buffer with a size
                   specified by num_form_fields must be provided by the
                   caller.
@@ -1652,7 +1652,7 @@ CIVETWEB_API unsigned mg_check_feature(unsigned feature);
      buffer: Store system information as string here.
      buflen: Length of buffer (including a byte required for a terminating 0).
    Return:
-     Available size of system information, exluding a terminating 0.
+     Available size of system information, excluding a terminating 0.
      The information is complete, if the return value is smaller than buflen.
      The result is a JSON formatted string, the exact content may vary.
    Note:
@@ -1669,7 +1669,7 @@ CIVETWEB_API int mg_get_system_info(char *buffer, int buflen);
      buffer: Store context information here.
      buflen: Length of buffer (including a byte required for a terminating 0).
    Return:
-     Available size of system information, exluding a terminating 0.
+     Available size of system information, excluding a terminating 0.
      The information is complete, if the return value is smaller than buflen.
      The result is a JSON formatted string, the exact content may vary.
      Note:
@@ -1698,7 +1698,7 @@ CIVETWEB_API void mg_disable_connection_keep_alive(struct mg_connection *conn);
      buffer: Store context information here.
      buflen: Length of buffer (including a byte required for a terminating 0).
    Return:
-     Available size of system information, exluding a terminating 0.
+     Available size of system information, excluding a terminating 0.
      The information is complete, if the return value is smaller than buflen.
      The result is a JSON formatted string, the exact content may vary.
    Note:

--- a/resources/Makefile.in-duktape
+++ b/resources/Makefile.in-duktape
@@ -46,7 +46,7 @@ ifeq ($(WITH_DUKTAPE_VERSION), 202)
 endif
 
 ifneq ($(DUKTAPE_VERSION_KNOWN), 1)
-  $(error Duktape: Unknwon version - $(WITH_DUKTAPE_VERSION))
+  $(error Duktape: Unknown version - $(WITH_DUKTAPE_VERSION))
 endif
 
 

--- a/resources/Makefile.in-lua
+++ b/resources/Makefile.in-lua
@@ -44,7 +44,7 @@ ifeq ($(WITH_LUA_VERSION), 504)
 endif
 
 ifneq ($(LUA_VERSION_KNOWN), 1)
-  $(error Lua: Unknwon version - $(WITH_LUA_VERSION))
+  $(error Lua: Unknown version - $(WITH_LUA_VERSION))
 endif
 
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -499,7 +499,7 @@ _civet_safe_clock_gettime(int clk_id, struct timespec *t)
 
 /********************************************************************/
 
-/* Helper makros */
+/* Helper macros */
 #if !defined(ARRAY_SIZE)
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 #endif
@@ -2508,7 +2508,7 @@ struct mg_connection {
 #if defined(USE_SERVER_STATS)
 	time_t conn_close_time; /* Time (wall clock) when connection was
 	                         * closed (or 0 if still open) */
-	double processing_time; /* Procesing time for one request. */
+	double processing_time; /* Processing time for one request. */
 #endif
 	struct timespec req_time; /* Time (since system start) when the request
 	                           * was received */
@@ -4486,7 +4486,7 @@ mg_send_http_error_impl(struct mg_connection *conn,
 						len = (int)sizeof(path_buf) - 32;
 					}
 
-					/* Start with the file extenstion from the configuration. */
+					/* Start with the file extension from the configuration. */
 					tstr = strchr(error_page_file_ext, '.');
 
 					while (tstr) {
@@ -4512,7 +4512,7 @@ mg_send_http_error_impl(struct mg_connection *conn,
 						DEBUG_TRACE("Check error page %s - not found",
 						            path_buf);
 
-						/* Continue with the next file extenstion from the
+						/* Continue with the next file extension from the
 						 * configuration (if there is a next one). */
 						tstr = strchr(tstr + i, '.');
 					}
@@ -5838,7 +5838,7 @@ spawn_process(struct mg_connection *conn,
 
 			interp = conn->dom_ctx->config[CGI_INTERPRETER + cgi_config_idx];
 			if (interp == NULL) {
-				/* no interpreter configured, call the programm directly */
+				/* no interpreter configured, call the program directly */
 				(void)execle(prog, prog, NULL, envp);
 				mg_cry_internal(conn,
 				                "%s: execle(%s): %s",
@@ -6374,7 +6374,7 @@ pull_inner(FILE *fp,
 				return -2;
 			}
 		} else if (pollres < 0) {
-			/* error callint poll */
+			/* error calling poll */
 			return -2;
 		} else {
 			/* pollres = 0 means timeout */
@@ -7569,7 +7569,7 @@ interpret_uri(struct mg_connection *conn, /* in/out: request (must be valid) */
               struct mg_file_stat *filestat, /* out: file status structure */
               int *is_found,                 /* out: file found (directly) */
               int *is_script_resource,       /* out: handled by a script? */
-              int *is_websocket_request,     /* out: websocket connetion? */
+              int *is_websocket_request,     /* out: websocket connection? */
               int *is_put_or_delete_request, /* out: put/delete a file? */
               int *is_webdav_request,        /* out: webdav request? */
               int *is_template_text          /* out: SSI file or LSP file? */
@@ -7786,7 +7786,7 @@ interpret_uri(struct mg_connection *conn, /* in/out: request (must be valid) */
 	                   "yes");
 	if (*is_webdav_request) {
 		/* TO BE DEFINED: Should scripts handle special WebDAV methods lile
-		 * PROPFIND fo their subresources? */
+		 * PROPFIND for their subresources? */
 		/* allow_substitute_script_subresources = 0; */
 	}
 
@@ -8995,7 +8995,7 @@ is_authorized_for_put(struct mg_connection *conn)
 		}
 	}
 
-	DEBUG_TRACE("file write autorization: %i", ret);
+	DEBUG_TRACE("file write authorization: %i", ret);
 	return ret;
 }
 #endif
@@ -10531,7 +10531,7 @@ put_dir(struct mg_connection *conn, const char *path)
 		/* Try to create intermediate directory */
 		DEBUG_TRACE("mkdir(%s)", buf);
 		if (!mg_stat(conn, buf, &file.stat) && mg_mkdir(conn, buf, 0755) != 0) {
-			/* path does not exixt and can not be created */
+			/* path does not exist and can not be created */
 			res = -2;
 			break;
 		}
@@ -10950,7 +10950,7 @@ parse_http_response(char *buf, int len, struct mg_response_info *ri)
 	ri->http_version = ri->status_text = NULL;
 	ri->num_headers = ri->status_code = 0;
 
-	/* RFC says that all initial whitespaces should be ingored */
+	/* RFC says that all initial whitespaces should be ignored */
 	/* This included all leading \r and \n (isspace) */
 	/* See table: http://www.cplusplus.com/reference/cctype/ */
 	while ((len > 0) && isspace((unsigned char)*buf)) {
@@ -12179,7 +12179,7 @@ put_file(struct mg_connection *conn, const char *path)
 	}
 
 	/* A file should be created or overwritten. */
-	/* Currently CivetWeb does not nead read+write access. */
+	/* Currently CivetWeb does not need read+write access. */
 	if (!mg_fopen(conn, path, MG_FOPEN_MODE_WRITE, &file)
 	    || file.access.fp == NULL) {
 		(void)mg_fclose(&file.access);
@@ -12333,7 +12333,7 @@ do_ssi_include(struct mg_connection *conn,
 
 	} else if ((sscanf(tag, " file=\"%511[^\"]\"", file_name) == 1)
 	           || (sscanf(tag, " \"%511[^\"]\"", file_name) == 1)) {
-		/* File name is relative to the currect document */
+		/* File name is relative to the current document */
 		file_name[511] = 0;
 		(void)mg_snprintf(conn, &truncated, path, sizeof(path), "%s", ssi);
 
@@ -13695,7 +13695,7 @@ handle_websocket_request(struct mg_connection *conn,
 		return;
 	}
 
-	/* Step 1.3: Could check for "Host", but we do not really nead this
+	/* Step 1.3: Could check for "Host", but we do not really need this
 	 * value for anything, so just ignore it. */
 
 	/* Step 2: If a callback is responsible, call it. */
@@ -13856,7 +13856,7 @@ should_switch_to_protocol(const struct mg_connection *conn)
 	const char *upgrade_to;
 	int connection_header_count, i, should_upgrade;
 
-	/* A websocket protocoll has the following HTTP headers:
+	/* A websocket protocol has the following HTTP headers:
 	 *
 	 * Connection: Upgrade
 	 * Upgrade: Websocket
@@ -14054,7 +14054,7 @@ set_throttle(const char *spec, const union usa *rsa, const char *uri)
 }
 
 
-/* The mg_upload function is superseeded by mg_handle_form_request. */
+/* The mg_upload function is superseded by mg_handle_form_request. */
 #include "handle_form.inl"
 
 
@@ -14706,7 +14706,7 @@ handle_request(struct mg_connection *conn)
 		url_decode_in_place((char *)ri->local_uri);
 	}
 
-	/* URL decode the query-string only if explicity set in the configuration */
+	/* URL decode the query-string only if explicitly set in the configuration */
 	if (conn->request_info.query_string) {
 		if (should_decode_query_string(conn)) {
 			url_decode_in_place((char *)conn->request_info.query_string);
@@ -15521,7 +15521,7 @@ parse_port_string(const struct vec *vec, struct socket *so, int *ip_version)
 		*ip_version = 4;
 
 	} else if ((cb = strchr(vec->ptr, ':')) != NULL) {
-		/* String could be a hostname. This check algotithm
+		/* String could be a hostname. This check algorithm
 		 * will only work for RFC 952 compliant hostnames,
 		 * starting with a letter, containing only letters,
 		 * digits and hyphen ('-'). Newer specs may allow
@@ -16128,7 +16128,7 @@ log_access(const struct mg_connection *conn)
 	/* Here we have a log message in log_buf. Call the callback */
 	if (conn->phys_ctx->callbacks.log_access) {
 		if (conn->phys_ctx->callbacks.log_access(conn, log_buf)) {
-			/* do not log if callack returns non-zero */
+			/* do not log if callback returns non-zero */
 			if (fi.access.fp) {
 				mg_fclose(&fi.access);
 			}
@@ -16485,7 +16485,7 @@ sslize(struct mg_connection *conn,
 					pollres =
 					    mg_poll(&pfd, 1, 50, &(conn->phys_ctx->stop_flag));
 					if (pollres < 0) {
-						/* Break if error occured (-1)
+						/* Break if error occurred (-1)
 						 * or server shutdown (-2) */
 						break;
 					}
@@ -16984,7 +16984,7 @@ ssl_get_protocol(int version_id)
  * examples, however some (maybe most, but not all) headers of OpenSSL
  * versions / OpenSSL compatibility layers have it. Having a different
  * definition will cause a warning in C and an error in C++. Use "const SSL
- * *", while automatical conversion from "SSL *" works for all compilers,
+ * *", while automatic conversion from "SSL *" works for all compilers,
  * but not other way around */
 static void
 ssl_info_callback(const SSL *ssl, int what, int ret)
@@ -17263,7 +17263,7 @@ init_ssl_ctx_impl(struct mg_context *phys_ctx,
 	                                                   phys_ctx->user_data));
 
 	/* If callback returns 0, civetweb sets up the SSL certificate.
-	 * If it returns 1, civetweb assumes the calback already did this.
+	 * If it returns 1, civetweb assumes the callback already did this.
 	 * If it returns -1, initializing ssl fails. */
 	if (callback_ret < 0) {
 		mg_cry_ctx_internal(phys_ctx,
@@ -17285,7 +17285,7 @@ init_ssl_ctx_impl(struct mg_context *phys_ctx,
 	                         phys_ctx->user_data));
 
 	/* If domain callback returns 0, civetweb sets up the SSL certificate.
-	 * If it returns 1, civetweb assumes the calback already did this.
+	 * If it returns 1, civetweb assumes the callback already did this.
 	 * If it returns -1, initializing ssl fails. */
 	if (callback_ret < 0) {
 		mg_cry_ctx_internal(phys_ctx,
@@ -18252,7 +18252,7 @@ mg_connect_client2(const char *host,
 		return NULL;
 	}
 
-	/* check all known protocolls */
+	/* check all known protocols */
 	if (!mg_strcasecmp(protocol, "http")) {
 		is_ssl = 0;
 		is_ws = 0;
@@ -19736,7 +19736,7 @@ worker_thread_run(struct mg_connection *conn)
 		                   sizeof(conn->request_info.remote_addr),
 		                   &conn->client.rsa);
 
-		DEBUG_TRACE("Incomming %sconnection from %s",
+		DEBUG_TRACE("Incoming %sconnection from %s",
 		            (conn->client.is_ssl ? "SSL " : ""),
 		            conn->request_info.remote_addr);
 
@@ -20262,7 +20262,7 @@ free_context(struct mg_context *ctx)
 		if (callback_ret == 0) {
 			SSL_CTX_free(ctx->dd.ssl_ctx);
 		}
-		/* else: ignore error and ommit SSL_CTX_free in case
+		/* else: ignore error and omit SSL_CTX_free in case
 		 * callback_ret is 1 */
 	}
 #endif /* !NO_SSL */

--- a/src/handle_form.inl
+++ b/src/handle_form.inl
@@ -220,7 +220,7 @@ mg_handle_form_request(struct mg_connection *conn,
 		}
 
 		/* GET request: form data is in the query string. */
-		/* The entire data has already been loaded, so there is no nead to
+		/* The entire data has already been loaded, so there is no need to
 		 * call mg_read. We just need to split the query string into key-value
 		 * pairs. */
 		data = conn->request_info.query_string;

--- a/src/http2.inl
+++ b/src/http2.inl
@@ -1835,7 +1835,7 @@ HPACK_TABLE_TEST()
 
 	for (i = 0; i < 256; i++) {
 		if (reverse_map[i] == -1) {
-			ck_abort_msg("reverse map at %i mising", i);
+			ck_abort_msg("reverse map at %i missing", i);
 		}
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -1302,7 +1302,7 @@ start_civetweb(int argc, char *argv[])
 				if (mg_strcasecmp(options[i + 1], "yes") == 0) {
 					fprintf(stdout, "daemonize.\n");
 					if (daemon(0, 0) != 0) {
-						fprintf(stdout, "Faild to daemonize main process.\n");
+						fprintf(stdout, "Failed to daemonize main process.\n");
 						exit(EXIT_FAILURE);
 					}
 					FILE *fp;
@@ -1726,7 +1726,7 @@ SettingsDlgProc(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lParam)
 				}
 
 				if (path[0] != '\0') {
-					/* Something has been choosen */
+					/* Something has been chosen */
 					SetWindowText(GetDlgItem(hDlg, ID_CONTROLS + i), path);
 				}
 			}

--- a/src/match.inl
+++ b/src/match.inl
@@ -68,7 +68,7 @@ mg_match_impl(const char *pat,
 
 		/* Pattern * or ** matches multiple characters */
 		if (pat[i_pat] == '*') {
-			size_t len; /* lenght matched by "*" or "**" */
+			size_t len; /* length matched by "*" or "**" */
 			ptrdiff_t ret;
 
 			i_pat++;

--- a/src/mod_lua.inl
+++ b/src/mod_lua.inl
@@ -946,7 +946,7 @@ lsp_include(lua_State *L)
 
 			} else if ((*path_type == 'r') || (*path_type == 'f')) {
 				/* "relative" = file name is relative to the
-				 * currect document */
+				 * current document */
 				(void)mg_snprintf(
 				    conn,
 				    &truncated,
@@ -1270,7 +1270,7 @@ lsp_split_form_urlencoded(lua_State *L)
 	/* Get input (const string) */
 	in = lua_tolstring(L, 1, &len);
 
-	/* Create a modifyable copy */
+	/* Create a modifiable copy */
 	buf = (char *)mg_malloc_ctx(len + 1, ctx);
 	if (buf == NULL) {
 		return luaL_error(L, "out of memory in invalid split_form_data() call");
@@ -1624,10 +1624,10 @@ lsp_random(lua_State *L)
 		/* The civetweb internal random number generator will generate
 		 * a 64 bit random number. */
 		uint64_t r = get_random();
-		/* Lua "number" is a IEEE 754 double precission float:
+		/* Lua "number" is a IEEE 754 double precision float:
 		 * https://en.wikipedia.org/wiki/Double-precision_floating-point_format
 		 * Thus, mask with 2^53-1 to get an integer with the maximum
-		 * precission available. */
+		 * precision available. */
 		r &= ((((uint64_t)1) << 53) - 1);
 		lua_pushnumber(L, (double)r);
 		return 1;
@@ -2485,7 +2485,7 @@ enum {
 	LUA_ENV_TYPE_LUA_SERVER_PAGE = 0, /* page.lp */
 	LUA_ENV_TYPE_PLAIN_LUA_PAGE = 1,  /* script.lua */
 	LUA_ENV_TYPE_LUA_WEBSOCKET = 2,   /* websock.lua */
-	LUA_ENV_TYPE_BACKGROUND = 9 /* Lua backgrond script or exec from cmdline */
+	LUA_ENV_TYPE_BACKGROUND = 9 /* Lua background script or exec from cmdline */
 };
 
 

--- a/src/mod_zlib.inl
+++ b/src/mod_zlib.inl
@@ -12,7 +12,7 @@ zalloc(void *opaque, uInt items, uInt size)
 {
 	struct mg_connection *conn = (struct mg_connection *)opaque;
 	void *ret = mg_calloc_ctx(items, size, conn->phys_ctx);
-	(void)conn; /* mg_calloc_ctx makro might not need it */
+	(void)conn; /* mg_calloc_ctx macro might not need it */
 
 	return ret;
 }

--- a/test/lua_backbround_script_logging.lua
+++ b/test/lua_backbround_script_logging.lua
@@ -44,7 +44,7 @@ function log(req, resp)
 	  logfile:flush();
 	end
 
-	-- Loging already done here
+	-- Logging already done here
 	return false;
 end
 

--- a/test/page.lp
+++ b/test/page.lp
@@ -48,7 +48,7 @@ The following features are available:
     );
   ]])
 
-  -- Add colums to table created with older version
+  -- Add columns to table created with older version
   db:exec("ALTER TABLE requests ADD COLUMN civetwebversion;")
   db:exec("ALTER TABLE requests ADD COLUMN luaversion;")
   db:exec("ALTER TABLE requests ADD COLUMN aux;")

--- a/test/page.lua
+++ b/test/page.lua
@@ -64,7 +64,7 @@ if db then
     );
   ]])
 
-  -- Add colums to table created with older version
+  -- Add columns to table created with older version
   db:exec("ALTER TABLE requests ADD COLUMN civetwebversion;")
   db:exec("ALTER TABLE requests ADD COLUMN luaversion;")
   db:exec("ALTER TABLE requests ADD COLUMN aux;")

--- a/unittest/private.c
+++ b/unittest/private.c
@@ -787,7 +787,7 @@ END_TEST
 
 START_TEST(test_is_valid_uri)
 {
-	/* is_valid_uri is superseeded by get_uri_type */
+	/* is_valid_uri is superseded by get_uri_type */
 	ck_assert_int_eq(2, get_uri_type("/api"));
 	ck_assert_int_eq(2, get_uri_type("/api/"));
 	ck_assert_int_eq(2,

--- a/unittest/public_func.c
+++ b/unittest/public_func.c
@@ -391,7 +391,7 @@ START_TEST(test_mg_get_var)
 	ck_assert_int_eq(ret, 10);
 	ck_assert_str_eq("this is it", buf);
 
-	/* longer value in the middle of a longer string - seccond occurrence of key
+	/* longer value in the middle of a longer string - second occurrence of key
 	 */
 	memset(buf, 77, sizeof(buf));
 	ret =

--- a/unittest/public_server.c
+++ b/unittest/public_server.c
@@ -1141,7 +1141,7 @@ websock_server_data(struct mg_connection *conn,
 	}
 	mark_point();
 
-	return 1; /* return 1 to keep the connetion open */
+	return 1; /* return 1 to keep the connection open */
 }
 
 
@@ -4995,8 +4995,8 @@ START_TEST(test_minimal_http_server_callback)
 	/* Call a test client */
 	minimal_http_client_check("127.0.0.1",
 	                          8080,
-	                          "/8?Altenative=Response",
-	                          "Altenative=Response");
+	                          "/8?Alternative=Response",
+	                          "Alternative=Response");
 
 	/* Run the server for 5 seconds */
 	test_sleep(5);
@@ -5103,8 +5103,8 @@ START_TEST(test_minimal_https_server_callback)
 	/* Call a test client */
 	minimal_https_client_check("127.0.0.1",
 	                           8443,
-	                           "/8?Altenative=Response",
-	                           "Altenative=Response");
+	                           "/8?Alternative=Response",
+	                           "Alternative=Response");
 
 	/* Run the server for 5 seconds */
 	test_sleep(5);


### PR DESCRIPTION
Hi @bel2125,

This fixes a lot of trivial spelling issues found by [codespell](https://github.com/codespell-project/codespell).
```bash
$ codespell -S ./src/third_party,./test/ajax/jquery.js,./CREDITS.md -L inout,searchin,selectin,ser,numer,clen,bu,ist,targetting,seh,succes,nnumber
```
Codespell could be easily added to the CI as well, for example via GitHub Actions.
Let me know what do you think about it, and I can submit a PR for that too.
