### PR TITLE
Fix -Wmissing-field-initializers in C++ code

### DIFF
--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -406,12 +406,12 @@ CivetServer::CivetServer(const char **options,
 		userCloseHandler = NULL;
 	}
 	callbacks.connection_close = closeHandler;
-	struct mg_init_data mg_start_init_data = {0};
+	struct mg_init_data mg_start_init_data = {};
 	mg_start_init_data.callbacks = &callbacks;
 	mg_start_init_data.user_data = this;
 	mg_start_init_data.configuration_options = options;
 
-	struct mg_error_data mg_start_error_data = {0};
+	struct mg_error_data mg_start_error_data = {};
 	char errtxtbuf[256] = {0};
 	mg_start_error_data.text = errtxtbuf;
 	mg_start_error_data.text_buffer_size = sizeof(errtxtbuf);
@@ -450,12 +450,12 @@ CivetServer::CivetServer(const std::vector<std::string> &options,
 	}
 	pointers.back() = NULL;
 
-	struct mg_init_data mg_start_init_data = {0};
+	struct mg_init_data mg_start_init_data = {};
 	mg_start_init_data.callbacks = &callbacks;
 	mg_start_init_data.user_data = this;
 	mg_start_init_data.configuration_options = &pointers[0];
 
-	struct mg_error_data mg_start_error_data = {0};
+	struct mg_error_data mg_start_error_data = {};
 	char errtxtbuf[256] = {0};
 	mg_start_error_data.text = errtxtbuf;
 	mg_start_error_data.text_buffer_size = sizeof(errtxtbuf);


### PR DESCRIPTION
Unlike C, where `= {0}` is universal zero initialization, in C++ code this pattern is regular field initialization and therefore emits:

```
missing field '...' initializer [-Wmissing-field-initializers]
```

[`= {}`](https://en.cppreference.com/w/cpp/language/zero_initialization) can be used, instead.