### PR TITLE
Fix compilation of USE_LUA without USE_TIMERS

### DIFF
--- a/src/mod_lua.inl
+++ b/src/mod_lua.inl
@@ -2905,8 +2905,8 @@ prepare_lua_environment(struct mg_context *ctx,
 	    || (lua_env_type == LUA_ENV_TYPE_BACKGROUND)) {
 		reg_function(L, "set_timeout", lwebsocket_set_timeout);
 		reg_function(L, "set_interval", lwebsocket_set_interval);
-#endif
 	}
+#endif
 
 	reg_conn_function(L, "get_mime_type", lsp_get_mime_type, conn);
 	reg_conn_function(L, "get_option", lsp_get_option, conn);


### PR DESCRIPTION
Currently, CivetWeb cannot be compiled with `USE_LUA` but without `USE_TIMERS` due to a syntax error. This error is fixed herein.

This has been hidden so far because of

https://github.com/civetweb/civetweb/blob/d7ba35bbb649209c66e582d5a0244ba988a15159/src/civetweb.c#L95-L97

I noticed this after realizing that `civetweb-timer` uses a lot more CPU time than all the `civetweb-workers` together:
![Screenshot from 2023-04-15 12-34-10](https://user-images.githubusercontent.com/16748619/232208875-7b0a4adc-5261-4f56-809e-d695fae0fdc5.png)

and simply force-disabling `USE_TIMERS` caused compilation to fail. I meanwhile bandaid-fixed the issue be externally forcing `TIMER_RESOLUTION=1000` which should be good enough for the default timeout values.