### PR TITLE
Fix mg_get_cookie() parameter description

### DIFF
--- a/docs/api/mg_get_cookie.md
+++ b/docs/api/mg_get_cookie.md
@@ -6,8 +6,8 @@
 
 | Parameter | Type | Description |
 | :--- | :--- | :--- |
-|**`cookie`**|`const char *`|The cookie name|
-|**`var_name`**|`const char *`|The variable name|
+|**`cookie`**|`const char *`|The unparsed cookie header|
+|**`var_name`**|`const char *`|The cookie name|
 |**`buf`**|`char *`|The buffer where to store the contents of the cookie|
 |**`buf_len`**|`size_t`|The length of the cookie buffer, including the terminating NUL|
 


### PR DESCRIPTION
The current docs are a bit confusing, because `cookie` is not intended to be the name but the entire unparsed header that a variable shall be extracted from.