### PR TITLE
Add API for I/O-ready-notification-callbacks on user-specified file descriptors

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -643,6 +643,14 @@ CIVETWEB_API void *mg_get_user_context_data(const struct mg_connection *conn);
 /* Get user defined thread pointer for server threads (see init_thread). */
 CIVETWEB_API void *mg_get_thread_pointer(const struct mg_connection *conn);
 
+#if defined(MG_EXPERIMENTAL_INTERFACES)
+/* Returns a socket-descriptor that will become ready-for-read when mg_stop() is
+ * called on the given context.  No data should be read from or written to this socket;
+ * it is provided for event-notification purposes (e.g. via poll() or select() or similar)
+ * only.  The intended use is to allow user-implemented event-loops within callbacks to
+ * exit immediately when their hosting server-context is going away. */
+CIVETWEB_API int mg_get_context_shutdown_notification_socket(const struct mg_context *ctx);
+#endif
 
 /* Set user data for the current connection. */
 /* Note: CivetWeb callbacks use "struct mg_connection *conn" as input
@@ -1611,6 +1619,81 @@ CIVETWEB_API int mg_response_header_add_lines(struct mg_connection *conn,
  *  -4:    sending failed (network error)
  */
 CIVETWEB_API int mg_response_header_send(struct mg_connection *conn);
+
+
+#if defined(MG_EXPERIMENTAL_INTERFACES)
+/* Callback types for miscellaneous-socket-event handlers in C/C++.
+
+   mg_misc_socket_flags_provider
+       Is called just before CivetWeb calls poll() on the user-provided socket.
+       Its return-value will be used to populate the "events" field associated
+       with the user-provided socket.  If this callback-pointer is set to NULL,
+       then POLLIN will be assumed by default.
+
+       Parameters:
+         conn: The associated mg_connection object
+         sock_fd: The file descriptor of the user-provided socket this callback is about.
+
+       Return value:
+         0: don't detect any events associated with this socket
+         POLLIN: we'd like a notification-callback when the socket is ready-for-read.
+         POLLOUT: we'd like a notification-callback when the socket is ready-for-write.
+         POLLIN|POLLOUT: we'd like a notification-callback when the socket is either
+                         ready-for-read or ready-for-write.
+         [etc]
+
+   mg_misc_socket_data_handler
+       Is called when CivetWeb has detected that a user-provided socket descriptor
+       is ready for data exchange.  This callback should be implemented to perform
+       any I/O operations on the socket descriptor as necessary.
+
+       Parameters:
+         conn: The associated mg_connection object
+         sock_fd: The file descriptor of the user-provided socket this callback is about.
+         int ready_events_bit_chord:  the detected I/O conditions (e.g. POLLIN, POLLOUT,
+                                      or POLLIN|POLLOUT)
+       Return value:
+         1: keep the client connection open.
+         0: close the client connection.  (Note this closes the mg_connection, *not* sock_fd!)
+*/
+typedef int (*mg_misc_socket_flags_provider)(const struct mg_connection * conn,
+                                             int sock_fd);
+typedef int (*mg_misc_socket_data_handler)(struct mg_connection * conn,
+                                           int sock_fd,
+                                           int ready_events_bit_chord);
+
+
+/* Install or remove a socket-IO-is-ready callback for a specified
+ * file descriptor.  This can be used to handle auxilliary I/O related
+ * to a given mg_connection, without having to spawn additional threads.
+ * These callbacks will remain until the connection (conn) is closed.
+ *
+ * Parameters:
+ *   conn: client connection that these callbacks are associated with
+ *   sock_fd: a file descriptor that the handler code would like to get callbacks
+ *            about, when I/O is ready on it.  Note that this is typically NOT the
+ *            the connection to the client itself, as that I/O is handled internally.
+ *   handler_callback: the function that should be called when I/O is ready on
+ *           the socket, or NULL to remove a previously-installed callback for (sockFD)
+ *   event_flags_query_callback: if non-NULL, this callback function will be called before
+ *                               each call to poll(), to find out what type(s) of I/O event the
+ *                               handler_callback should be called for.  Should return a bit-chord
+ *                               of desired event-types (e.g. POLLIN|POLLOUT if you want to
+ *                               be notified when socket is either ready-for-read or ready-for
+ *                               write).  If you pass in NULL, the default behavior will be
+ *                               used -- the default behavior is equivalent to a callback that
+ *                               always returns POLLIN; i.e. it will cause handler_callback
+ *                               to be called whenever (sock_fd) is ready-for-read.
+ * Return:
+ *    0:    ok
+ *   -1:    parameter error
+ *   -2:    out of memory
+ */
+CIVETWEB_API int mg_set_misc_socket_handler(const struct mg_connection *conn,
+                                            int sock_fd,
+                                            mg_misc_socket_data_handler handler_callback,
+                                            mg_misc_socket_flags_provider event_flags_query_callback);
+#endif
 
 
 /* Check which features where set when the civetweb library has been compiled.

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -2500,6 +2500,15 @@ struct mg_http2_connection {
 #endif
 
 
+#if defined(MG_EXPERIMENTAL_INTERFACES)
+/** Record of callback-settings that were set via mg_set_misc_socket_callback() */
+struct mg_misc_socket_callback {
+	int sock_fd;  /* Note:  owned by user-code; we won't close this! */
+	mg_misc_socket_flags_provider event_flags_query_callback;
+	mg_misc_socket_data_handler handler_callback;
+};
+#endif
+
 struct mg_connection {
 	int connection_type; /* see CONNECTION_TYPE_* above */
 	int protocol_type;   /* see PROTOCOL_TYPE_*: 0=http/1.x, 1=ws, 2=http/2 */
@@ -2584,6 +2593,16 @@ struct mg_connection {
 	                            * atomic transmissions for websockets */
 #if defined(USE_LUA) && defined(USE_WEBSOCKET)
 	void *lua_websocket_state; /* Lua_State for a websocket connection */
+#endif
+
+	struct mg_pollfd basic_mg_poll_fds_array[2];  /* these get used in the common (no-user-socket-callbacks) case */
+
+#if defined(MG_EXPERIMENTAL_INTERFACES)
+	struct mg_misc_socket_callback * misc_socket_callbacks;  /* NULL if none are installed */
+	int num_misc_socket_callbacks; /* how many items misc_socket_callbacks points to */
+
+	struct mg_pollfd * custom_mg_poll_fds_array;  /* dynamically allocated array (for custom-user-callbacks cases) */
+	int custom_mg_poll_fds_array_size;            /* number of items currently allocated in custom_mg_poll_fds_array (either 0 or 3+) */
 #endif
 
 	void *tls_user_ptr; /* User defined pointer in thread local storage,
@@ -3237,6 +3256,15 @@ mg_get_thread_pointer(const struct mg_connection *conn)
 		return tls->user_ptr;
 	}
 }
+
+
+#if defined(MG_EXPERIMENTAL_INTERFACES)
+CIVETWEB_API int
+mg_get_context_shutdown_notification_socket(const struct mg_context *ctx)
+{
+	return ctx->thread_shutdown_notification_socket;
+}
+#endif
 
 
 CIVETWEB_API void
@@ -5221,14 +5249,19 @@ mg_readdir(DIR *dir)
 
 
 #if !defined(HAVE_POLL)
-#undef POLLIN
-#undef POLLPRI
-#undef POLLOUT
-#undef POLLERR
-#define POLLIN (1)  /* Data ready - read will not block. */
-#define POLLPRI (2) /* Priority data ready. */
-#define POLLOUT (4) /* Send queue not full - write will not block. */
-#define POLLERR (8) /* Error event */
+
+/* Only define these constants if they aren't already defined by the system; otherwise
+ * we risk a mismatch between their values we test for in this file and the event-flags
+ * returned by the user-code's event_flags_query_callbacks.
+ *
+ * In particular, Windows specifies "interesting" values for these constants that are
+ * different from the ones defined below. */
+#if !defined(POLLIN) && !defined(POLLPRI) && !defined(POLLOUT) && !defined(POLLERR)
+# define POLLIN (1)  /* Data ready - read will not block. */
+# define POLLPRI (2) /* Priority data ready. */
+# define POLLOUT (4) /* Send queue not full - write will not block. */
+# define POLLERR (8) /* Error event */
+#endif
 
 FUNCTION_MAY_BE_UNUSED
 static int
@@ -5956,18 +5989,17 @@ static int
 mg_poll(struct mg_pollfd *pfd,
         unsigned int n,
         int milliseconds,
-        const stop_flag_t *stop_flag)
+        const stop_flag_t *stop_flag,
+        int check_pollerr_on_first_pfd)
 {
 	/* Call poll, but only for a maximum time of a few seconds.
 	 * This will allow to stop the server after some seconds, instead
 	 * of having to wait for a long socket timeout. */
 	int ms_now = SOCKET_TIMEOUT_QUANTUM; /* Sleep quantum in ms */
 
-	int check_pollerr = 0;
-	if ((n == 1) && ((pfd[0].events & POLLERR) == 0)) {
-		/* If we wait for only one file descriptor, wait on error as well */
+	if (check_pollerr_on_first_pfd) {
+		/* "man poll" says this will be ignored anyway, but I'm leaving it here, just in case the man page is wrong */
 		pfd[0].events |= POLLERR;
-		check_pollerr = 1;
 	}
 
 	do {
@@ -5985,13 +6017,13 @@ mg_poll(struct mg_pollfd *pfd,
 		result = poll(pfd, n, ms_now);
 		if (result != 0) {
 			int err = ERRNO;
-			if ((result == 1) || (!ERROR_TRY_AGAIN(err))) {
+			if ((result > 0) || (!ERROR_TRY_AGAIN(err))) {
 				/* Poll returned either success (1) or error (-1).
 				 * Forward both to the caller. */
-				if ((check_pollerr)
+				if ((check_pollerr_on_first_pfd)
 				    && ((pfd[0].revents & (POLLIN | POLLOUT | POLLERR))
 				        == POLLERR)) {
-					/* One and only file descriptor returned error */
+					/* First file descriptor returned error */
 					return -1;
 				}
 				return result;
@@ -6154,7 +6186,7 @@ push_inner(struct mg_context *ctx,
 
 			pfd[1].fd = ctx->thread_shutdown_notification_socket;
 			pfd[1].events = POLLIN;
-			pollres = mg_poll(pfd, 2, (int)(ms_wait), &(ctx->stop_flag));
+			pollres = mg_poll(pfd, 2, (int)(ms_wait), &(ctx->stop_flag), 1);
 			if (!STOP_FLAG_IS_ZERO(&ctx->stop_flag)) {
 				return -2;
 			}
@@ -6220,6 +6252,75 @@ push_all(struct mg_context *ctx,
 	return nwritten;
 }
 
+/** Returns a pointer to the mg_poll_fd array to pass to mg_poll() for the given mg_connection,
+  * or NULL on failure.
+  * On successful return, (*ret_num_pfds) will contain the number of valid mg_pollfd items that
+  * our returned pointer is pointing to.
+  */
+static struct mg_pollfd *
+mg_get_poll_fds_for_connection(struct mg_connection * conn,
+                               int * ret_num_pfds,
+                               int connection_fd_events_bits)
+{
+	struct mg_pollfd * ret = conn->basic_mg_poll_fds_array;
+	int num_pfds = 2;  /* We always have at least client.sock and thread_shutdown_notification_socket */
+#if defined(MG_EXPERIMENTAL_INTERFACES)
+	if (conn->num_misc_socket_callbacks > 0) {
+		num_pfds += conn->num_misc_socket_callbacks;
+		if (num_pfds != conn->custom_mg_poll_fds_array_size) {
+			struct mg_pollfd * new_fds = (struct mg_pollfd *)
+				mg_realloc_ctx(conn->custom_mg_poll_fds_array,
+		                        num_pfds*sizeof(conn->custom_mg_poll_fds_array[0]),
+		                        conn->phys_ctx);
+			if (new_fds == NULL) {
+				return NULL;  /* out of memory? */
+			}
+			conn->custom_mg_poll_fds_array = new_fds;
+			conn->custom_mg_poll_fds_array_size = num_pfds;
+		}
+
+		ret = conn->custom_mg_poll_fds_array;
+		for (int i=0; i<conn->num_misc_socket_callbacks; i++) {
+			const struct mg_misc_socket_callback * cb = &conn->misc_socket_callbacks[i];
+			struct mg_pollfd * pfd = &ret[i+2];  /* the first two pfds are internal and will be set up separately at the end of this function */
+			pfd->fd = cb->sock_fd;
+			pfd->events = cb->event_flags_query_callback ? cb->event_flags_query_callback(conn, cb->sock_fd) : POLLIN;
+		}
+	}
+#endif
+
+	ret[0].fd = conn->client.sock;
+	ret[0].events = connection_fd_events_bits;
+
+	ret[1].fd = conn->phys_ctx->thread_shutdown_notification_socket;
+	ret[1].events = POLLIN;
+
+	*ret_num_pfds = num_pfds;
+	return ret;
+}
+
+static int
+mg_dispatch_misc_socket_callbacks(struct mg_connection * conn)
+{
+#if defined(MG_EXPERIMENTAL_INTERFACES)
+	int ret = 1;  /* defaults to success */
+	const struct mg_pollfd * pfd = conn->custom_mg_poll_fds_array;
+	const struct mg_misc_socket_callback * cb = conn->misc_socket_callbacks;
+	if ((pfd)&&(cb)) {
+		pfd += 2;  /* the first two pfds are always handled internally, so we skip them here */
+
+		for (int i=0; i<conn->num_misc_socket_callbacks; i++) {
+			if (pfd[i].revents != 0) {
+				ret &= cb[i].handler_callback(conn, pfd[i].fd, pfd[i].revents);
+			}
+		}
+	}
+	return ret;
+#else
+	(void) conn;  /* avoid compiler warning */
+	return 1;
+#endif
+}
 
 /* Read from IO channel - opened file descriptor, socket, or SSL descriptor.
  * Return value:
@@ -6265,6 +6366,7 @@ pull_inner(FILE *fp,
 		struct mg_pollfd pfd[2];
 		int to_read;
 		int pollres;
+		int client_is_ready_for_read = 0;
 
 		to_read = mbedtls_ssl_get_bytes_avail(conn->ssl);
 
@@ -6277,25 +6379,28 @@ pull_inner(FILE *fp,
 			if (to_read > len)
 				to_read = len;
 		} else {
-			pfd[0].fd = conn->client.sock;
-			pfd[0].events = POLLIN;
-
-			pfd[1].fd = conn->phys_ctx->thread_shutdown_notification_socket;
-			pfd[1].events = POLLIN;
+			int num_pfds;
+			struct mg_pollfd * pfd = mg_get_poll_fds_for_connection(conn, &num_pfds, POLLIN);
 
 			to_read = len;
 
-			pollres = mg_poll(pfd,
-			                  2,
+			pollres = pfds ? mg_poll(pfd,
+			                  num_pfds,
 			                  (int)(timeout * 1000.0),
-			                  &(conn->phys_ctx->stop_flag));
-
+			                  &(conn->phys_ctx->stop_flag),
+			                  1) : -1;
 			if (!STOP_FLAG_IS_ZERO(&conn->phys_ctx->stop_flag)) {
 				return -2;
 			}
+			if (pollres > 0) {
+				if (mg_dispatch_misc_socket_callbacks(conn) == 0) {
+					return -2;
+				}
+				client_is_ready_for_read = ((pfd[0].revents & POLLIN) != 0);
+			}
 		}
 
-		if (pollres > 0) {
+		if (client_is_ready_for_read) {
 			nread = mbed_ssl_read(conn->ssl, (unsigned char *)buf, to_read);
 			if (nread <= 0) {
 				if ((nread == MBEDTLS_ERR_SSL_WANT_READ)
@@ -6309,7 +6414,6 @@ pull_inner(FILE *fp,
 			} else {
 				err = 0;
 			}
-
 		} else if (pollres < 0) {
 			/* Error */
 			return -2;
@@ -6321,8 +6425,8 @@ pull_inner(FILE *fp,
 #elif !defined(NO_SSL)
 	} else if (conn->ssl != NULL) {
 		int ssl_pending;
-		struct mg_pollfd pfd[2];
 		int pollres;
+		int client_is_ready_for_read = 0;
 
 		if ((ssl_pending = SSL_pending(conn->ssl)) > 0) {
 			/* We already know there is no more data buffered in conn->buf
@@ -6333,20 +6437,25 @@ pull_inner(FILE *fp,
 			}
 			pollres = 1;
 		} else {
-			pfd[0].fd = conn->client.sock;
-			pfd[0].events = POLLIN;
-			pfd[1].fd = conn->phys_ctx->thread_shutdown_notification_socket;
-			pfd[1].events = POLLIN;
-
-			pollres = mg_poll(pfd,
-			                  2,
+			int num_pfds;
+			struct mg_pollfd * pfd = mg_get_poll_fds_for_connection(conn, &num_pfds, POLLIN);
+			pollres = pfd ? mg_poll(pfd,
+			                  num_pfds,
 			                  (int)(timeout * 1000.0),
-			                  &(conn->phys_ctx->stop_flag));
+			                  &(conn->phys_ctx->stop_flag),
+			                  1) : -1;
+			if (pollres > 0) {
+				if (mg_dispatch_misc_socket_callbacks(conn) == 0) {
+					return -2;
+				}
+				client_is_ready_for_read = ((pfd[0].revents & POLLIN) != 0);
+			}
+
 			if (!STOP_FLAG_IS_ZERO(&conn->phys_ctx->stop_flag)) {
 				return -2;
 			}
 		}
-		if (pollres > 0) {
+		if (client_is_ready_for_read) {
 			ERR_clear_error();
 			nread =
 			    SSL_read(conn->ssl, buf, (ssl_pending > 0) ? ssl_pending : len);
@@ -6377,28 +6486,32 @@ pull_inner(FILE *fp,
 #endif
 
 	} else {
-		struct mg_pollfd pfd[2];
 		int pollres;
 
-		pfd[0].fd = conn->client.sock;
-		pfd[0].events = POLLIN;
-
-		pfd[1].fd = conn->phys_ctx->thread_shutdown_notification_socket;
-		pfd[1].events = POLLIN;
-
-		pollres = mg_poll(pfd,
-		                  2,
+		int num_pfds;
+		struct mg_pollfd * pfd = mg_get_poll_fds_for_connection(conn, &num_pfds, POLLIN);
+		pollres = pfd ? mg_poll(pfd,
+		                  num_pfds,
 		                  (int)(timeout * 1000.0),
-		                  &(conn->phys_ctx->stop_flag));
+		                  &(conn->phys_ctx->stop_flag),
+		                  1) : -1;
 		if (!STOP_FLAG_IS_ZERO(&conn->phys_ctx->stop_flag)) {
 			return -2;
 		}
 		if (pollres > 0) {
-			nread = (int)recv(conn->client.sock, buf, (len_t)len, 0);
-			err = (nread < 0) ? ERRNO : 0;
-			if (nread <= 0) {
-				/* shutdown of the socket at client side */
+			if (mg_dispatch_misc_socket_callbacks(conn) == 0) {
 				return -2;
+			}
+			if ((pfd[0].revents & POLLIN) != 0) {
+				nread = (int)recv(conn->client.sock, buf, (len_t)len, 0);
+				err = (nread < 0) ? ERRNO : 0;
+				if (nread <= 0) {
+					/* shutdown of the socket at client side */
+					return -2;
+				}
+			} else {
+				/* some other socket was ready, but not the client socket */
+				nread = 0;
 			}
 		} else if (pollres < 0) {
 			/* error calling poll */
@@ -9558,7 +9671,7 @@ connect_socket(
 		pfd[1].fd = ctx ? ctx->thread_shutdown_notification_socket : -1;
 		pfd[1].events = POLLIN;
 
-		pollres = mg_poll(pfd, ctx ? 2 : 1, ms_wait, ctx ? &(ctx->stop_flag) : &nonstop);
+		pollres = mg_poll(pfd, ctx ? 2 : 1, ms_wait, ctx ? &(ctx->stop_flag) : &nonstop, 1);
 
 		if (pollres != 1) {
 			/* Not connected */
@@ -16576,22 +16689,31 @@ sslize(struct mg_connection *conn,
 					/* Need to retry the function call "later".
 					 * See https://linux.die.net/man/3/ssl_get_error
 					 * This is typical for non-blocking sockets. */
-					struct mg_pollfd pfd[2];
 					int pollres;
-					pfd[0].fd = conn->client.sock;
-					pfd[0].events = ((err == SSL_ERROR_WANT_CONNECT)
+
+					int primary_fd_events = ((err == SSL_ERROR_WANT_CONNECT)
 					                || (err == SSL_ERROR_WANT_WRITE))
 					                   ? POLLOUT
 					                   : POLLIN;
+					int num_pfds;
+					struct mg_pollfd * pfd =
+					     mg_get_poll_fds_for_connection(conn, &num_pfds, primary_fd_events);
 
-					pfd[1].fd = conn->phys_ctx->thread_shutdown_notification_socket;
-					pfd[1].events = POLLIN;
+					if (pfd == NULL) {
+						mg_cry_internal(conn, "%s: SSL mg_get_poll_fds_for_connection() failed", __func__);
+						break;
+					}
+
 					pollres =
-					    mg_poll(pfd, 2, 50, &(conn->phys_ctx->stop_flag));
+					    mg_poll(pfd, num_pfds, 50, &(conn->phys_ctx->stop_flag), 1);
 					if (pollres < 0) {
 						/* Break if error occurred (-1)
 						 * or server shutdown (-2) */
 						break;
+					} else if (pollres > 0) {
+						if (mg_dispatch_misc_socket_callbacks(conn) == 0) {
+							break;  /* error out (and then free(conn->ssl) below) */
+						}
 					}
 				}
 
@@ -17903,6 +18025,25 @@ close_socket_gracefully(struct mg_connection *conn)
 }
 #endif
 
+static void
+mg_clear_misc_socket_callbacks(struct mg_connection *conn)
+{
+#if defined(MG_EXPERIMENTAL_INTERFACES)
+	if (conn->misc_socket_callbacks) {
+		mg_free(conn->misc_socket_callbacks);
+	}
+	conn->misc_socket_callbacks     = NULL;
+	conn->num_misc_socket_callbacks = 0;
+
+	if (conn->custom_mg_poll_fds_array) {
+		mg_free(conn->custom_mg_poll_fds_array);
+	}
+	conn->custom_mg_poll_fds_array      = NULL;
+	conn->custom_mg_poll_fds_array_size = 0;
+#else
+	(void) conn;  /* avoid compiler warning */
+#endif
+}
 
 static void
 close_connection(struct mg_connection *conn)
@@ -17933,6 +18074,7 @@ close_connection(struct mg_connection *conn)
 	/* Reset user data, after close callback is called.
 	 * Do not reuse it. If the user needs a destructor,
 	 * it must be done in the connection_close callback. */
+	mg_clear_misc_socket_callbacks(conn);
 	mg_set_user_connection_data(conn, NULL);
 
 #if defined(USE_SERVER_STATS)
@@ -19386,6 +19528,7 @@ init_connection(struct mg_connection *conn)
 	conn->handled_requests = 0;
 	conn->connection_type = CONNECTION_TYPE_INVALID;
 	conn->request_info.acceptedWebSocketSubprotocol = NULL;
+	mg_clear_misc_socket_callbacks(conn);
 	mg_set_user_connection_data(conn, NULL);
 
 #if defined(USE_SERVER_STATS)
@@ -20180,7 +20323,8 @@ master_thread_run(struct mg_context *ctx)
 		if (mg_poll(pfd,
 		            ctx->num_listening_sockets+1,   // +1 for the thread_shutdown_notification_socket
 		            SOCKET_TIMEOUT_QUANTUM,
-		            &(ctx->stop_flag))
+		            &(ctx->stop_flag),
+		            0)
 		    > 0) {
 			for (i = 0; i < ctx->num_listening_sockets; i++) {
 				/* NOTE(lsm): on QNX, poll() returns POLLRDNORM after the
@@ -22176,6 +22320,77 @@ mg_disable_connection_keep_alive(struct mg_connection *conn)
 		conn->must_close = 1;
 	}
 }
+
+
+#if defined(MG_EXPERIMENTAL_INTERFACES)
+CIVETWEB_API int
+mg_set_misc_socket_handler(const struct mg_connection *cconn,
+			   int sock_fd,
+			   mg_misc_socket_data_handler handler_callback,
+			   mg_misc_socket_flags_provider event_flags_query_callback)
+{
+	struct mg_connection * conn = (struct mg_connection *) cconn;
+	if ((conn == NULL)||(sock_fd < 0)) {
+		return -1;  /* invalid parameter */
+	}
+
+	/** Find the location of any existing record (if any) for the specified sock_fd */
+	struct mg_misc_socket_callback * cbs = conn->misc_socket_callbacks;
+	int num_cbs = conn->num_misc_socket_callbacks;
+	int cur_cb_index = -1;
+	if (cbs) {
+		for (int i=0; i<num_cbs; i++) {
+			if (cbs[i].sock_fd == sock_fd) {
+				cur_cb_index = i;
+				break;
+			}
+		}
+	}
+
+	if (handler_callback) {
+		if (cur_cb_index < 0) {
+			/* Unknown socket - append a new item to our callback-records array */
+			struct mg_misc_socket_callback * new_cbs =
+				(struct mg_misc_socket_callback *)mg_realloc_ctx(cbs,
+					(num_cbs+1)*(sizeof(cbs[0])), conn->phys_ctx);
+			if (new_cbs == NULL) {
+				return -2;  /* out of memory */
+			}
+			cur_cb_index = num_cbs;
+
+			conn->misc_socket_callbacks = new_cbs;
+			conn->num_misc_socket_callbacks++;
+		}
+
+		struct mg_misc_socket_callback * new_cb = &conn->misc_socket_callbacks[cur_cb_index];
+		new_cb->sock_fd = sock_fd;
+		new_cb->handler_callback = handler_callback;
+		new_cb->event_flags_query_callback = event_flags_query_callback;
+	}
+	else if (cur_cb_index >= 0) {
+		/* Remove a previously-installed callback-record */
+		if (num_cbs == 1) {
+			mg_free(cbs);
+			conn->misc_socket_callbacks = NULL;
+		} else {
+			for (int i=cur_cb_index; (i+1)<num_cbs; i++) {
+				cbs[i] = cbs[i+1];
+			}
+
+			struct mg_misc_socket_callback * new_cbs =
+				(struct mg_misc_socket_callback *)mg_realloc_ctx(cbs,
+					(num_cbs-1)*(sizeof(cbs[0])), conn->phys_ctx);
+			if (new_cbs == NULL) {
+				return -2;  /* out of memory */
+			}
+			conn->misc_socket_callbacks = new_cbs;
+		}
+		conn->num_misc_socket_callbacks--;
+	}
+
+	return 0;  /* success */
+}
+#endif
 
 
 #if defined(MG_EXPERIMENTAL_INTERFACES)


### PR DESCRIPTION
This pull request makes the following changes which add support for in-thread monitoring of user-specified file-descriptors, so that the calling code doesn't have to spawn (and/or synchronize with) additional threads in order to do back-end I/O to support the connection.

1. Adds an argument to `mg_poll()` telling it whether or not to do the special checking for `POLLERR` on the first pfd in the array (necessary because the old approach -- implicitly enabling that logic iff there was exactly one socket in the array -- doesn't work anymore now that there are always at least two sockets in the array, and sometimes more)
2. Adds a new private/internal function `mg_get_poll_fds_for_connection()` that sets up a pfd-array to pass to `mg_poll()` and returns a pointer to it.  Calls to this function replace the duplicated pfd-array-setup code that was previously present at multiple locations within civetweb.c.
3. Adds a new public/experimental function `mg_set_misc_socket_handler()` that allows the user-callback code to register one or more of its own file descriptors with the `mg_connection` for inclusion in the array passed to `mg_poll()`.   This function is only enabled if `MG_EXPERIMENTAL_INTERFACES` is defined.
4. Adds a new private/internal function `mg_dispatch_misc_socket_callbacks()` that is called after `mg_poll()` returns, and which calls the appropriate user-supplied `mg_misc_socket_data_handler` callback-methods to allow user-code to read or write to their registered file-descriptor as appropriate, after it has poll'd as ready-for-read and/or ready-for-write.  (See issue #1161)
5. Adds a new public/experimental function `mg_get_context_shutdown_notification_socket()` that returns a file-descriptor that will poll as ready-for-read when the server wants to shut down ASAP.  This is useful for callbacks that are looping in their own synchronous internal event-loop but want to be polite and return quickly if the process wants to go away.   This function is only enabled `MG_EXPERIMENTAL_INTERFACES` is defined.  (See Issue #1160)