### PR TITLE
Add support for more CORS headers

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -4209,6 +4209,24 @@ send_cors_header(struct mg_connection *conn)
 		                       -1);
 	}
 
+	const char *cors_hdr_cfg =
+	    conn->dom_ctx->config[ACCESS_CONTROL_ALLOW_HEADERS];
+	if (cors_hdr_cfg && *cors_hdr_cfg) {
+	   mg_response_header_add(conn,
+	                          "Access-Control-Allow-Headers",
+	                          cors_hdr_cfg,
+	                          -1);
+	}
+
+	const char *cors_meth_cfg =
+	      conn->dom_ctx->config[ACCESS_CONTROL_ALLOW_METHODS];
+	if (cors_meth_cfg && *cors_meth_cfg) {
+	   mg_response_header_add(conn,
+	                          "Access-Control-Allow-Methods",
+	                          cors_meth_cfg,
+	                          -1);
+	}
+
 }
 
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -15024,6 +15024,13 @@ handle_request(struct mg_connection *conn)
 			          ((cors_meth_cfg[0] == '*') ? cors_acrm : cors_meth_cfg),
 			          suggest_connection_header(conn));
 
+			const char *cors_cred_cfg =
+			      conn->dom_ctx->config[ACCESS_CONTROL_ALLOW_CREDENTIALS];
+			if (cors_cred_cfg && *cors_cred_cfg)
+			   mg_printf(conn,
+			             "Access-Control-Allow-Credentials: %s\r\n",
+			             cors_cred_cfg);
+
 			if (cors_acrh != NULL) {
 				/* CORS request is asking for additional headers */
 				const char *cors_hdr_cfg =

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -2059,6 +2059,7 @@ enum {
 	ACCESS_CONTROL_ALLOW_ORIGIN,
 	ACCESS_CONTROL_ALLOW_METHODS,
 	ACCESS_CONTROL_ALLOW_HEADERS,
+	ACCESS_CONTROL_ALLOW_CREDENTIALS,
 	ERROR_PAGES,
 #if !defined(NO_CACHING)
 	STATIC_FILE_MAX_AGE,
@@ -2222,6 +2223,7 @@ static const struct mg_option config_options[] = {
     {"access_control_allow_origin", MG_CONFIG_TYPE_STRING, "*"},
     {"access_control_allow_methods", MG_CONFIG_TYPE_STRING, "*"},
     {"access_control_allow_headers", MG_CONFIG_TYPE_STRING, "*"},
+    {"access_control_allow_credentials", MG_CONFIG_TYPE_STRING, ""},
     {"error_pages", MG_CONFIG_TYPE_DIRECTORY, NULL},
 #if !defined(NO_CACHING)
     {"static_file_max_age", MG_CONFIG_TYPE_NUMBER, "3600"},
@@ -4195,6 +4197,18 @@ send_cors_header(struct mg_connection *conn)
 		                       cors_orig_cfg,
 		                       -1);
 	}
+
+	const char *cors_cred_cfg =
+	    conn->dom_ctx->config[ACCESS_CONTROL_ALLOW_CREDENTIALS];
+	if (cors_cred_cfg && *cors_cred_cfg && origin_hdr && *origin_hdr) {
+		/* Cross-origin resource sharing (CORS), see
+		 * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials */
+		mg_response_header_add(conn,
+		                       "Access-Control-Allow-Credentials",
+		                       cors_cred_cfg,
+		                       -1);
+	}
+
 }
 
 


### PR DESCRIPTION
For CORS requests using authentication one need to add `Access-Control-Allow-Credentials` header.
Together with that header two other CORS headers should be provided  - `Access-Control-Allow-Headers` and `Access-Control-Allow-Methods`.
Also add `Access-Control-Expose-Headers` header. It is need for JavaScript applications which try to access some 'unsafe' fields in the http CORS response. For instance, one need it to get 'Accept-Ranges' value from the CORS response - while this header is not [listed as safe](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header)
