### PR TITLE
Jaf poll notification callbacks second attempt

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -1653,7 +1653,7 @@ CIVETWEB_API int mg_response_header_send(struct mg_connection *conn);
          1: keep the client connection open.
          0: close the client connection.  (Note this closes the mg_connection, *not* sock_fd!)
 */
-typedef int (*mg_misc_socket_flags_provider)(const struct mg_connection * conn,
+typedef short (*mg_misc_socket_flags_provider)(const struct mg_connection * conn,
                                              int sock_fd);
 typedef int (*mg_misc_socket_data_handler)(struct mg_connection * conn,
                                            int sock_fd,

--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -643,6 +643,12 @@ CIVETWEB_API void *mg_get_user_context_data(const struct mg_connection *conn);
 /* Get user defined thread pointer for server threads (see init_thread). */
 CIVETWEB_API void *mg_get_thread_pointer(const struct mg_connection *conn);
 
+/* Returns a socket-descriptor that will become ready-for-read when mg_stop() is
+ * called on the given context.  No data should be read from or written to this socket;
+ * it is provided for event-notification purposes (e.g. via poll() or select() or similar)
+ * only.  The intended use is to allow user-implemented event-loops within callbacks to
+ * exit immediately when their hosting server-context is going away. */
+CIVETWEB_API int mg_get_context_shutdown_notification_socket(const struct mg_context *ctx);
 
 /* Set user data for the current connection. */
 /* Note: CivetWeb callbacks use "struct mg_connection *conn" as input
@@ -1611,6 +1617,79 @@ CIVETWEB_API int mg_response_header_add_lines(struct mg_connection *conn,
  *  -4:    sending failed (network error)
  */
 CIVETWEB_API int mg_response_header_send(struct mg_connection *conn);
+
+
+/* Callback types for miscellaneous-socket-event handlers in C/C++.
+
+   mg_misc_socket_flags_provider
+       Is called just before CivetWeb calls poll() on the user-provided socket.
+       Its return-value will be used to populate the "events" field associated
+       with the user-provided socket.  If this callback-pointer is set to NULL,
+       then POLLIN will be assumed by default.
+
+       Parameters:
+         conn: The associated mg_connection object
+         sock_fd: The file descriptor of the user-provided socket this callback is about.
+
+       Return value:
+         0: don't detect any events associated with this socket
+         POLLIN: we'd like a notification-callback when the socket is ready-for-read.
+         POLLOUT: we'd like a notification-callback when the socket is ready-for-write.
+         POLLIN|POLLOUT: we'd like a notification-callback when the socket is either
+                         ready-for-read or ready-for-write.
+         [etc]
+
+   mg_misc_socket_data_handler
+       Is called when CivetWeb has detected that a user-provided socket descriptor
+       is ready for data exchange.  This callback should be implemented to perform
+       any I/O operations on the socket descriptor as necessary.
+
+       Parameters:
+         conn: The associated mg_connection object
+         sock_fd: The file descriptor of the user-provided socket this callback is about.
+         int ready_events_bit_chord:  the detected I/O conditions (e.g. POLLIN, POLLOUT,
+                                      or POLLIN|POLLOUT)
+       Return value:
+         1: keep the client connection open.
+         0: close the client connection.  (Note this closes the mg_connection, *not* sock_fd!)
+*/
+typedef int (*mg_misc_socket_flags_provider)(const struct mg_connection * conn,
+                                             int sock_fd);
+typedef int (*mg_misc_socket_data_handler)(struct mg_connection * conn,
+                                           int sock_fd,
+                                           int ready_events_bit_chord);
+
+
+/* Install or remove a socket-IO-is-ready callback for a specified
+ * file descriptor.  This can be used to handle auxilliary I/O related
+ * to a given mg_connection, without having to spawn additional threads.
+ * These callbacks will remain until the connection (conn) is closed.
+ *
+ * Parameters:
+ *   conn: client connection that these callbacks are associated with
+ *   sock_fd: a file descriptor that the handler code would like to get callbacks
+ *            about, when I/O is ready on it.  Note that this is typically NOT the
+ *            the connection to the client itself, as that I/O is handled internally.
+ *   handler_callback: the function that should be called when I/O is ready on
+ *           the socket, or NULL to remove a previously-installed callback for (sockFD)
+ *   event_flags_query_callback: if non-NULL, this callback function will be called before
+ *                               each call to poll(), to find out what type(s) of I/O event the
+ *                               handler_callback should be called for.  Should return a bit-chord
+ *                               of desired event-types (e.g. POLLIN|POLLOUT if you want to
+ *                               be notified when socket is either ready-for-read or ready-for
+ *                               write).  If you pass in NULL, the default behavior will be
+ *                               used -- the default behavior is equivalent to a callback that
+ *                               always returns POLLIN; i.e. it will cause handler_callback
+ *                               to be called whenever (sock_fd) is ready-for-read.
+ * Return:
+ *    0:    ok
+ *   -1:    parameter error
+ *   -2:    out of memory
+ */
+CIVETWEB_API int mg_set_misc_socket_handler(const struct mg_connection *conn,
+                                            int sock_fd,
+                                            mg_misc_socket_data_handler handler_callback,
+                                            mg_misc_socket_flags_provider event_flags_query_callback);
 
 
 /* Check which features where set when the civetweb library has been compiled.


### PR DESCRIPTION
(second attempt -- I closed my previous pull-request on this topic as the merging was messy.  This one merges cleanly against the current master branch)

This pull-request makes the following changes which add support for in-thread monitoring of user-specified file-descriptors, so that the calling code doesn't have to spawn (and/or synchronize with) additional threads in order to do the back-end I/O necessary to support the civetweb-client-connection.

- Adds a new public function `mg_set_misc_socket_handler()` that allows the user's code to register one or more of its own file-descriptors with the `mg_connection` for inclusion in the `mg_pollfd`-array that `civetweb.c` passes to its `mg_poll()` calls.

- Adds a new public function `int mg_get_context_shutdown_notification_socket()` that returns a file-descriptor that will poll as ready-for-read iff the server wants to shut down ASAP. This is useful for callbacks that are looping in their own synchronous internal event-loop but want to be responsive and return quickly when the CivetWeb process is shutting down.  (See issue #1160)

- Adds a new private/internal function `mg_dispatch_misc_socket_callbacks()` that the code in `civetweb.c` calls after `mg_poll()` returns.  This function calls the user's callback-functions (as previously registered via `mg_set_misc_socket_handler()` when appropriate, so that the user-code can handle the registered sockets' I/O as necessary. (See issue #1161)

- Adds a new private/internal function `mg_get_poll_fds_for_connection()` that sets up a pfd-array to pass to mg_poll() and returns a pointer to it. Calls to this function replace the duplicated pfd-array-setup code that was previously present at multiple locations within `civetweb.c`.

- Adds a boolean-argument to private function `mg_poll()` telling it whether or not to do the special checking for POLLERR on the first pfd in the array (necessary because the old approach -- implicitly enabling that logic iff there was exactly one socket in the array -- doesn't work anymore, now that there are always at least two sockets in the array, and sometimes more)