### PR TITLE
Fix the wrong report of http header transferring timeout.

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -11328,11 +11328,11 @@ read_message(FILE *fp,
 			request_len = get_http_header_len(buf, *nread);
 		}
 
-		if ((request_len == 0) && (request_timeout >= 0)) {
+		if ((n <= 0) && (request_timeout >= 0)) {
 			if (mg_difftimespec(&last_action_time, &(conn->req_time))
 			    > request_timeout) {
 				/* Timeout */
-				return -1;
+				return -3;
 			}
 		}
 	}
@@ -18816,7 +18816,7 @@ get_message(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 			            ebuf,
 			            ebuf_len,
 			            "%s",
-			            "Malformed message");
+			            conn->request_len == -3 ? "Request timeout" : "Malformed message");
 			*err = 400;
 		} else {
 			/* Server did not recv anything -> just close the connection */


### PR DESCRIPTION
For now, the connection is not closed at first keep_alive_timeout_ms interval, if the whole header can not be read in the second interval at one time, then return failed.
However, the http header can be transferred in two packages. Especially in https, there will be one byte exchanged before the real data transferring. This can lead to wrong header transferred timeout when two request are sended more than a keep_alive_timeout_ms interval.