### PR TITLE
Self-signed certificate key size from 1024 to 2048

### DIFF
--- a/docs/OpenSSL.md
+++ b/docs/OpenSSL.md
@@ -46,7 +46,7 @@ One can use the following steps in Windows (in Linux replace "copy" by "cp"
 and "type" by "cat"):
 
 <pre>
-  openssl genrsa -des3 -out server.key 1024
+  openssl genrsa -des3 -out server.key 2048
 
   openssl req -new -key server.key -out server.csr
 


### PR DESCRIPTION
The current self-signed certificate doesn't work. It will cause an SSL error (EE_KEY_TOO_SMALL) when loading the PEM file.