### PR TITLE
Fix compiling CivetWeb + mbedTLS in DEBUG mode

### DIFF
--- a/src/mod_mbedtls.inl
+++ b/src/mod_mbedtls.inl
@@ -188,7 +188,11 @@ mbed_ssl_accept(mbedtls_ssl_context **ssl,
 		return -1;
 	}
 
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+	DEBUG_TRACE("TLS connection %p accepted, state: %d", ssl, (*ssl)->MBEDTLS_PRIVATE(state));
+#else
 	DEBUG_TRACE("TLS connection %p accepted, state: %d", ssl, (*ssl)->state);
+#endif
 	return 0;
 }
 
@@ -214,7 +218,11 @@ mbed_ssl_handshake(mbedtls_ssl_context *ssl)
 		}
 	}
 
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+	DEBUG_TRACE("TLS handshake rc: %d, state: %d", rc, ssl->MBEDTLS_PRIVATE(state));
+#else
 	DEBUG_TRACE("TLS handshake rc: %d, state: %d", rc, ssl->state);
+#endif
 	return rc;
 }
 


### PR DESCRIPTION
The element `int state` in `struct mbedtls_ssl_context` is only available using the macro `MBEDTLS_PRIVATE(state)` for mbedTLS v3+. This was forgotten in https://github.com/civetweb/civetweb/pull/1144