### PR TITLE
Truly allow all non-control characters in URIs

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -10843,8 +10843,9 @@ static int
 skip_to_end_of_word_and_terminate(char **ppw, int eol)
 {
 	/* Forward until a space is found - use isgraph here */
+	/* Extended ASCII characters are also treated as word characters. */
 	/* See http://www.cplusplus.com/reference/cctype/ */
-	while (isgraph((unsigned char)**ppw)) {
+	while ((unsigned char)**ppw > 127 || isgraph((unsigned char)**ppw)) {
 		(*ppw)++;
 	}
 
@@ -18639,7 +18640,7 @@ get_uri_type(const char *uri)
 	 * and % encoded symbols.
 	 */
 	for (i = 0; uri[i] != 0; i++) {
-		if (uri[i] < 33) {
+		if ((unsigned char)uri[i] < 33) {
 			/* control characters and spaces are invalid */
 			return 0;
 		}


### PR DESCRIPTION
Back in July 2020, https://github.com/civetweb/civetweb/commit/688969fdddb431a7f0c729be66a51dd81fcba73e allowed all non-control characters in URLs to fix #894. However, this commit does not properly allow extended-ASCII characters due to checking `uri[i] < 33` where `uri` is a `signed char`. As consequence, everything beyond 127 will actually be considered to be negative and misinterpreted as control character in this check.

This issue was discovered when we saw that some `curl` versions send, e.g., Umlauts (`aöüß`) as they are (228, 246, 252, 223). To be clear, we are not talking about "ancient" versions here but, e.g., version 7.81.0 from last year which is shipped with many distros, a prime example being the current Ubuntu LTS.

Even more recent versions of `curl` (tested 7.88.0) seem to percent-encode Umlauts before sending to the web server, but as I found nothing mentioning this between both version in [`curl`'s CHANGELOG](https://curl.se/changes.html), I assume that this may be a compile-time setting so we should not rely on this.

Legitimate requests containing Umlauts are currently rejected by CivetWeb, e.g. `myserver.local/name/mühle.com` (mind the Umlaut `ü`). This PR fixes this by preventing extended ASCII characters to be rejected prematurely.