### PR TITLE
Fix building with MbedTLS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,10 +47,10 @@ endif()
 
 # We need to link OpenSSL if not dynamically loading
 if (CIVETWEB_ENABLE_SSL)
-  if (CIVETWEB_ENBALE_MBEDTLS)
+  if (CIVETWEB_ENABLE_MBEDTLS)
     find_package(MbedTLS)
     include_directories(${MbedTLS_INCLUDE_DIR})
-    message(STATUS "MbedTLS include directory: {MbedTLS_INCLUDE_DIR}")
+    message(STATUS "MbedTLS include directory: ${MbedTLS_INCLUDE_DIR}")
     target_link_libraries(civetweb-c-library ${MbedTLS_LIBRARIES})
   else()
     if (CIVETWEB_ENABLE_SSL_DYNAMIC_LOADING)


### PR DESCRIPTION
MbedTLS builds had two typos, one of them significant. This PR fixes both of them.