### PR TITLE
Disable `mg_` reminders when `NDEBUG` is defined

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -1551,11 +1551,13 @@ static void mg_snprintf(const struct mg_connection *conn,
 #if defined(vsnprintf)
 #undef vsnprintf
 #endif
+#if !defined(NDEBUG)
 #define malloc DO_NOT_USE_THIS_FUNCTION__USE_mg_malloc
 #define calloc DO_NOT_USE_THIS_FUNCTION__USE_mg_calloc
 #define realloc DO_NOT_USE_THIS_FUNCTION__USE_mg_realloc
 #define free DO_NOT_USE_THIS_FUNCTION__USE_mg_free
 #define snprintf DO_NOT_USE_THIS_FUNCTION__USE_mg_snprintf
+#endif
 #if defined(_WIN32)
 /* vsnprintf must not be used in any system,
  * but this define only works well for Windows. */


### PR DESCRIPTION
We are currently running into an issue trying to integrate civetweb as submodule and its reminder definitions creating interferences. 

https://github.com/civetweb/civetweb/blob/cd12e4737424fa9c266aaaf89909dcae617d2e51/src/civetweb.c#L1534-L1535

So I thought might fit to also disable the reminders when `NDEBUG` is defined, as they likely can be classified as debug info. 

