### PR TITLE
Update CIVETWEB_VERSION to 1.16.0 in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ include(AddCXXCompilerFlag)
 include(DetermineTargetArchitecture)
 include(CMakeDependentOption)
 
-set(CIVETWEB_VERSION "1.15.0" CACHE STRING "The version of the civetweb library")
+set(CIVETWEB_VERSION "1.16.0" CACHE STRING "The version of the civetweb library")
 string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" CIVETWEB_VERSION_MATCH "${CIVETWEB_VERSION}")
 if ("${CIVETWEB_VERSION_MATCH}" STREQUAL "")
   message(FATAL_ERROR "Must specify a semantic version: major.minor.patch")


### PR DESCRIPTION
Our call to `find_package(civetweb 1.16.0 EXACT CONFIG REQUIRED)` is failing with version 1.16 of civetweb installed via vcpkg. It appears that this is because `CIVETWEB_VERSION` is incorrectly set as `1.15.0` and therefore `civetweb-config-version.cmake` contains the wrong version. Consequently, there is no way to explicitly require version 1.16.0, because both 1.15.0 and 1.16.0 are the same version according to cmake.