### PR TITLE
Send correct HTTP error code when serving custom error pages

### DIFF
--- a/src/mod_lua.inl
+++ b/src/mod_lua.inl
@@ -641,7 +641,10 @@ run_lsp_kepler(struct mg_connection *conn,
 		/* Only send a HTML header, if this is the top level page.
 		 * If this page is included by some mg.include calls, do not add a
 		 * header. */
-		mg_printf(conn, "HTTP/1.1 200 OK\r\n");
+		if(conn->status_code < 0)
+			mg_printf(conn, "HTTP/1.1 200 OK\r\n");
+		else
+			mg_printf(conn, "HTTP/1.1 %d %s\r\n", conn->status_code, mg_get_response_code_text(conn, conn->status_code));
 		send_no_cache_header(conn);
 		send_additional_header(conn);
 		mg_printf(conn,


### PR DESCRIPTION
Currently, this is broken for Lua server pages where, e.g., even 404 errors are served with HTTP 200 OK while they clearly shouldn't. When using error pages with Kepler syntax, this results in a situation that cannot even be recovered from the script itself as Kepler syntax doesn't allow sending custom headers.

How to reproduce: Define a custom error page using Lua, e.g., `error404.lp` and observe that it is served as `200 OK`. With this patch, the expected error code is returned as expected:

![image](https://github.com/user-attachments/assets/b1eaf6ec-ab4f-4d28-acca-3637ad913cf2)
