### PR TITLE
mbedTLS: Fix TLS 1.3 support

### DIFF
--- a/src/mod_mbedtls.inl
+++ b/src/mod_mbedtls.inl
@@ -88,6 +88,18 @@ mbed_sslctx_init(SSL_CTX *ctx, const char *crt)
 	mbedtls_ctr_drbg_init(&ctx->ctr);
 	mbedtls_x509_crt_init(&ctx->cert);
 
+#ifdef MBEDTLS_PSA_CRYPTO_C
+	/* Initialize PSA crypto (mandatory with TLS 1.3)
+	 * This must be done before calling any other PSA Crypto
+	 * functions or they will fail with PSA_ERROR_BAD_STATE
+	 */
+	const psa_status_t status = psa_crypto_init();
+	if (status != PSA_SUCCESS) {
+		DEBUG_TRACE("Failed to initialize PSA crypto, returned %d\n", (int) status);
+		return -1;
+	}
+#endif
+
 	rc = mbedtls_ctr_drbg_seed(&ctx->ctr,
 	                           mbedtls_entropy_func,
 	                           &ctx->entropy,


### PR DESCRIPTION
This PR adds missing PSA (Platform Security Architecture) cryptography API initialization.

Calling `psa_crypto_init()` is mandatory when PSA is used which is, in turn, mandatory when using TLS 1.3 (`MBEDTLS_SSL_PROTO_TLS1_3`). When not being initialized, the server will finish startup but any encrypted traffic will cause errors deep inside the mbedTLS library (return code `0x6c00 == MBEDTLS_ERR_SSL_INTERNAL_ERROR`) and screens like:

![Screenshot from 2024-08-15 20-35-17](https://github.com/user-attachments/assets/548bdcdf-9796-4350-b17d-4909798644e5)

With this change, TLS 1.3 works as expected with CivetWeb (current `master`) and mbedTLS (latest release, 3.6.0).

----

See https://github.com/Mbed-TLS/mbedtls/blob/v3.6.0/include/mbedtls/mbedtls_config.h#L1772-L1794:

``` c
/**
 * \def MBEDTLS_SSL_PROTO_TLS1_3
 *
 * Enable support for TLS 1.3.
 *
 * \note See docs/architecture/tls13-support.md for a description of the TLS
 *       1.3 support that this option enables.
 *
 * Requires: MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
 * Requires: MBEDTLS_PSA_CRYPTO_C
 *
 * \note TLS 1.3 uses PSA crypto for cryptographic operations that are           <-------------
 *       directly performed by TLS 1.3 code. As a consequence, you must          <-------------
 *       call psa_crypto_init() before the first TLS 1.3 handshake.              <-------------
 *
 * \note Cryptographic operations performed indirectly via another module
 *       (X.509, PK) or by code shared with TLS 1.2 (record protection,
 *       running handshake hash) only use PSA crypto if
 *       #MBEDTLS_USE_PSA_CRYPTO is enabled.
 *
 * Uncomment this macro to enable the support for TLS 1.3.
 */
#define MBEDTLS_SSL_PROTO_TLS1_3
```