### PR TITLE
Add dependabot to keep github-actions up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "10:00"
+  open-pull-requests-limit: 10
+  target-branch: master


### PR DESCRIPTION
Within the `.github` workflow, different actions are used. Most of them are pinned to outdated versions. This PR will add [Dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) to the repo which will run weekly and open PRs to keep the actions up-to-date.