### PR TITLE
Fix LUA error reporting

### DIFF
--- a/src/mod_lua.inl
+++ b/src/mod_lua.inl
@@ -673,7 +673,9 @@ run_lsp_kepler(struct mg_connection *conn,
 
 	} else {
 		/* Success loading chunk. Call it. */
-		lua_pcall(L, 0, 0, 1);
+		lua_ok = lua_pcall(L, 0, 0, 0);
+		if(lua_ok != LUA_OK)
+			lua_cry(conn, lua_ok, L, "LSP", "call");
 	}
 	return 0;
 }
@@ -789,7 +791,9 @@ run_lsp_civetweb(struct mg_connection *conn,
 						lua_pcall(L, 1, 0, 0);
 					} else {
 						/* Success loading chunk. Call it. */
-						lua_pcall(L, 0, 0, 1);
+						lua_ok = lua_pcall(L, 0, 0, 0);
+						if(lua_ok != LUA_OK)
+							lua_cry(conn, lua_ok, L, "LSP", "call");
 					}
 
 					/* Progress until after the Lua closing tag. */


### PR DESCRIPTION
This PR seeks fixing error reporting when handling Lua server pages.

Before, CivetWeb used [`lua_pcall(L, nargs, nresults, errfunc)`](https://www.lua.org/pil/25.2.html) with `errfunc = 1` when reporting errors. `errfunc = 1` specifies that the error handler is to be found on stack index 1 which seemingly isn't the case - at least, I have found no code ensuring that `mg.onerror` is exactly here and tests showed it is not.

Anyway, the result in my testing is an infinite loop of error reporting as the code always again reaches [this `goto`](https://github.com/lua/lua/blob/fd0e1f530d06340f99334b07d74e5133ce073787/ldo.c#L679) jumping back to [here](https://github.com/lua/lua/blob/fd0e1f530d06340f99334b07d74e5133ce073787/ldo.c#L654) eventually leading to a C stack overflow in Lua. Depending on the platform, this either causes the application to crash (segfault), sometimes even in unrelated code due to stack corruption, sometimes nothing bad at all happens but the error message is still never printed (because the error handler isn't ever being called).

The solution is pretty simple: Don't use a custom error handler but rely on the return value of `lua_pcall()` returning `!= LUA_OK` and, if so, defer what we got to the existing `lua_cry` function handling the error message and printing something like:
```
LSP: call failed: runtime error: [string "test2.lp"]:2: attempt to call a nil value (field 'blahblah')
```
when my code looks like
``` lua
<?
string.blahblah()
?>
```