### PR TITLE
Add OpenSSL3.0 test and drop OpenSSL1.0 tests

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -44,8 +44,8 @@ jobs:
               N: Clang-Linux-Default-Release
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
-              OPENSSL_1_0: YES
-              OPENSSL_1_1: NO
+              OPENSSL_1_0: NO
+              OPENSSL_1_1: YES
               ENABLE_CXX: NO
               ENABLE_LUA_SHARED: NO
               C_STANDARD: auto
@@ -69,8 +69,8 @@ jobs:
               N: GCC-Linux-Complete-NoLua-Release
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
-              OPENSSL_1_0: YES
-              OPENSSL_1_1: NO
+              OPENSSL_1_0: NO
+              OPENSSL_1_1: YES
               ENABLE_CXX: NO
               ENABLE_LUA_SHARED: NO
               C_STANDARD: auto
@@ -94,8 +94,8 @@ jobs:
               N: CLANG-AnyVersion-Linux-Coverage
               BUILD_TYPE: Coverage
               ENABLE_SSL_DYNAMIC_LOADING: YES
-              OPENSSL_1_0: YES
-              OPENSSL_1_1: NO
+              OPENSSL_1_0: NO
+              OPENSSL_1_1: YES
               ENABLE_CXX: NO
               ENABLE_LUA_SHARED: NO
               C_STANDARD: auto
@@ -144,8 +144,8 @@ jobs:
               N: GCCLinuxDefault_RelWithDebInfo
               BUILD_TYPE: RelWithDebInfo
               ENABLE_SSL_DYNAMIC_LOADING: YES
-              OPENSSL_1_0: YES
-              OPENSSL_1_1: NO
+              OPENSSL_1_0: NO
+              OPENSSL_1_1: YES
               ENABLE_CXX: NO
               ENABLE_LUA_SHARED: NO
               C_STANDARD: auto
@@ -168,8 +168,8 @@ jobs:
               N: GCCLinuxDefault_MinSizeRel
               BUILD_TYPE: MinSizeRel
               ENABLE_SSL_DYNAMIC_LOADING: YES
-              OPENSSL_1_0: YES
-              OPENSSL_1_1: NO
+              OPENSSL_1_0: NO
+              OPENSSL_1_1: YES
               ENABLE_CXX: NO
               ENABLE_LUA_SHARED: NO
               C_STANDARD: auto
@@ -192,8 +192,8 @@ jobs:
               N: GCCLinuxDefault_None
               BUILD_TYPE: None
               ENABLE_SSL_DYNAMIC_LOADING: YES
-              OPENSSL_1_0: YES
-              OPENSSL_1_1: NO
+              OPENSSL_1_0: NO
+              OPENSSL_1_1: YES
               ENABLE_CXX: NO
               ENABLE_LUA_SHARED: NO
               C_STANDARD: auto
@@ -216,8 +216,8 @@ jobs:
               N: GCCLinuxDefault_xenial
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
-              OPENSSL_1_0: YES
-              OPENSSL_1_1: NO
+              OPENSSL_1_0: NO
+              OPENSSL_1_1: YES
               ENABLE_CXX: NO
               ENABLE_LUA_SHARED: NO
               C_STANDARD: auto
@@ -237,7 +237,7 @@ jobs:
           - os: ubuntu-latest
             compiler: gcc
             env:
-              N: GCCLinuxDefault_focal
+              N: GCCLinuxDefault
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO
@@ -335,17 +335,14 @@ jobs:
               ALLOW_WARNINGS: YES
               RUN_UNITTEST: 1
 
-          # mac-os 13 is the last version of MacOS runner using x86_64 architecture
-          # mac-os 14 and later are using arm64 architecture
-          # but OpenSSL 1.0 can't compile on arm64, so we set it fixed to mac-os 13
-          - os: macos-13
+          - os: macos-latest
             compiler: clang
             env:
-              N: OSX-Package_OpenSSL_1_0
+              N: OSX-Package_OpenSSL_1_1
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
-              OPENSSL_1_0: YES
-              OPENSSL_1_1: NO
+              OPENSSL_1_0: NO
+              OPENSSL_1_1: YES
               ENABLE_CXX: NO
               ENABLE_LUA_SHARED: NO
               C_STANDARD: auto
@@ -403,31 +400,6 @@ jobs:
             sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
             sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
 
-        - name: Install OpenSSL 1.0 on modern MacOS
-          # Needed for recent versions of MacOS as they ship with OpenSSL 1.1 by default
-          if: startsWith(matrix.os,'macos') && matrix.env.OPENSSL_1_0 == 'YES'
-          run: |
-            curl -O -L https://openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz
-            tar -xzf openssl-1.0.2u.tar.gz
-            cd openssl-1.0.2u
-            ./Configure --prefix=/usr/local/ssl1.0 --openssldir=/usr/local/ssl1.0 shared shared darwin64-x86_64-cc
-            make depend
-            make -j $(nproc)
-            sudo make install_sw -j $(nproc)
-
-            OPENSSL_ROOT_DIR=/usr/local/ssl1.0
-            LDFLAGS=-L${OPENSSL_ROOT_DIR}/lib
-            CFLAGS=-I${OPENSSL_ROOT_DIR}/include
-            ADDITIONAL_CMAKE_ARGS="-DCMAKE_SHARED_LINKER_FLAGS=${LDFLAGS} -DMAKE_C_FLAGS=${CFLAGS}"
-            PKG_CONFIG_PATH=${OPENSSL_ROOT_DIR}/lib/pkgconfig
-            
-            echo "LDFLAGS=${LDFLAGS}" >> $GITHUB_ENV
-            echo "CFLAGS=${CFLAGS}" >> $GITHUB_ENV
-            echo "${OPENSSL_ROOT_DIR}/bin" >> $GITHUB_PATH
-            echo "ADDITIONAL_CMAKE_ARGS=${ADDITIONAL_CMAKE_ARGS}" >> $GITHUB_ENV
-            echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> $GITHUB_ENV
-            echo "DYLD_LIBRARY_PATH=${OPENSSL_ROOT_DIR}/lib" >> $GITHUB_ENV
-        
         - name: Set up OpenSSL 1.1 on modern MacOS
           # OpenSSL 1.1 is installed by default, so we just need to set the paths
           if: startsWith(matrix.os,'macos') && matrix.env.OPENSSL_1_1 == 'YES'
@@ -437,57 +409,35 @@ jobs:
             CFLAGS=-I${OPENSSL_ROOT_DIR}/include
             ADDITIONAL_CMAKE_ARGS="-DCMAKE_SHARED_LINKER_FLAGS=${LDFLAGS} -DMAKE_C_FLAGS=${CFLAGS}"
             PKG_CONFIG_PATH=${OPENSSL_ROOT_DIR}/lib/pkgconfig
+            DYLD_LIBRARY_PATH=${OPENSSL_ROOT_DIR}/lib
             
             echo "LDFLAGS=${LDFLAGS}" >> $GITHUB_ENV
             echo "CFLAGS=${CFLAGS}" >> $GITHUB_ENV
             echo "${OPENSSL_ROOT_DIR}/bin" >> $GITHUB_PATH
             echo "ADDITIONAL_CMAKE_ARGS=${ADDITIONAL_CMAKE_ARGS}" >> $GITHUB_ENV
             echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> $GITHUB_ENV
+            echo "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}" >> $GITHUB_ENV
 
         - name: Install OpenSSL 3.0 on modern MacOS
           # OpenSSL 1.1 is installed by default, so we need to install 3.0 manually
           if: startsWith(matrix.os,'macos') && matrix.env.OPENSSL_3_0 == 'YES'            
           run: |
             brew install openssl@3.0
-            
+             
             OPENSSL_ROOT_DIR=$(brew --prefix openssl@3.0)
             LDFLAGS=-L${OPENSSL_ROOT_DIR}/lib
             CFLAGS=-I${OPENSSL_ROOT_DIR}/include
             ADDITIONAL_CMAKE_ARGS="-DCMAKE_SHARED_LINKER_FLAGS=${LDFLAGS} -DMAKE_C_FLAGS=${CFLAGS}"
             PKG_CONFIG_PATH=${OPENSSL_ROOT_DIR}/lib/pkgconfig
+            DYLD_LIBRARY_PATH=${OPENSSL_ROOT_DIR}/lib
 
             echo "LDFLAGS=${LDFLAGS}" >> $GITHUB_ENV
             echo "CFLAGS=${CFLAGS}" >> $GITHUB_ENV
             echo "${OPENSSL_ROOT_DIR}/bin" >> $GITHUB_PATH
             echo "ADDITIONAL_CMAKE_ARGS=${ADDITIONAL_CMAKE_ARGS}" >> $GITHUB_ENV
             echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> $GITHUB_ENV
-
-        - name: Install OpenSSL 1.0 on modern Linux
-          # Needed for recent versions of Linux as they ship with OpenSSL 3.0 by default
-          if: startsWith(matrix.os,'ubuntu') && matrix.env.OPENSSL_1_0 == 'YES'
-          run: |
-            curl -O -L https://openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz
-            tar -xzf openssl-1.0.2u.tar.gz
-            cd openssl-1.0.2u
-            ./config --prefix=/usr/local/ssl1.0 --openssldir=/usr/local/ssl1.0 shared
-            make depend
-            make -j $(nproc)
-            sudo make install_sw -j $(nproc)
-            sudo ldconfig
-
-            OPENSSL_ROOT_DIR=/usr/local/ssl1.0
-            LDFLAGS=-L${OPENSSL_ROOT_DIR}/lib
-            CFLAGS=-I${OPENSSL_ROOT_DIR}/include
-            ADDITIONAL_CMAKE_ARGS="-DCMAKE_SHARED_LINKER_FLAGS=${LDFLAGS} -DMAKE_C_FLAGS=${CFLAGS}"
-            PKG_CONFIG_PATH=${OPENSSL_ROOT_DIR}/lib/pkgconfig
-            
-            echo "LDFLAGS=${LDFLAGS}" >> $GITHUB_ENV
-            echo "CFLAGS=${CFLAGS}" >> $GITHUB_ENV
-            echo "${OPENSSL_ROOT_DIR}/bin" >> $GITHUB_PATH
-            echo "ADDITIONAL_CMAKE_ARGS=${ADDITIONAL_CMAKE_ARGS}" >> $GITHUB_ENV
-            echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> $GITHUB_ENV
-            echo "LD_LIBRARY_PATH=${OPENSSL_ROOT_DIR}/lib" >> $GITHUB_ENV
-        
+            echo "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}" >> $GITHUB_ENV
+       
         - name: Install OpenSSL 1.1 on modern Linux
           # Needed for recent versions of Linux as they ship  with OpenSSL 3.0 by default
           if: startsWith(matrix.os,'ubuntu') && matrix.env.OPENSSL_1_1 == 'YES'

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -7,8 +7,9 @@ on:
     types: [published]
   workflow_dispatch:
 jobs:
-  build:
+  build-and-test:
     runs-on: ${{ matrix.os }}
+    name: ${{ matrix.env.NAME }}
     strategy:
       fail-fast: true
       matrix:
@@ -16,7 +17,7 @@ jobs:
           - os: ubuntu-latest
             compiler: clang
             env:
-              N: Clang-Linux-Minimal-Debug
+              NAME: Clang-Linux-Minimal-Debug
               BUILD_TYPE: Debug
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO
@@ -41,7 +42,7 @@ jobs:
           - os: ubuntu-latest
             compiler: clang
             env:
-              N: Clang-Linux-Default-Release
+              NAME: Clang-Linux-Default-Release
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO
@@ -66,7 +67,7 @@ jobs:
           - os: ubuntu-latest
             compiler: gcc 
             env:
-              N: GCC-Linux-Complete-NoLua-Release
+              NAME: GCC-Linux-Complete-NoLua-Release
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO
@@ -91,7 +92,7 @@ jobs:
           - os: ubuntu-latest
             compiler: clang
             env:
-              N: CLANG-AnyVersion-Linux-Coverage
+              NAME: CLANG-AnyVersion-Linux-Coverage
               BUILD_TYPE: Coverage
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO
@@ -116,7 +117,7 @@ jobs:
           - os: ubuntu-latest
             compiler: clang
             env:
-              N: Clang-Linux-Default-Shared
+              NAME: Clang-Linux-Default-Shared
               BUILD_TYPE: Debug
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO
@@ -141,7 +142,7 @@ jobs:
           - os: ubuntu-latest
             compiler: gcc
             env:
-              N: GCCLinuxDefault_RelWithDebInfo
+              NAME: GCCLinuxDefault_RelWithDebInfo
               BUILD_TYPE: RelWithDebInfo
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO
@@ -165,7 +166,7 @@ jobs:
           - os: ubuntu-latest
             compiler: gcc
             env:
-              N: GCCLinuxDefault_MinSizeRel
+              NAME: GCCLinuxDefault_MinSizeRel
               BUILD_TYPE: MinSizeRel
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO
@@ -189,7 +190,7 @@ jobs:
           - os: ubuntu-latest
             compiler: gcc
             env:
-              N: GCCLinuxDefault_None
+              NAME: GCCLinuxDefault_None
               BUILD_TYPE: None
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO
@@ -213,7 +214,7 @@ jobs:
           - os: ubuntu-latest
             compiler: gcc
             env:
-              N: GCCLinuxDefault_xenial
+              NAME: GCCLinuxDefault_xenial
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO
@@ -237,7 +238,7 @@ jobs:
           - os: ubuntu-latest
             compiler: gcc
             env:
-              N: GCCLinuxDefault
+              NAME: GCCLinuxDefault
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO
@@ -261,7 +262,7 @@ jobs:
           - os: ubuntu-latest
             compiler: gcc
             env:
-              N: GCCLinuxDefault_OpenSSL_3_0
+              NAME: GCCLinuxDefault_OpenSSL_3_0
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO
@@ -288,7 +289,7 @@ jobs:
           # - os: ubuntu-lastest
           #   compiler: clang
           #   env:
-          #     N: Clang-Linux-Complete-WithLua-Debug
+          #     NAME: Clang-Linux-Complete-WithLua-Debug
           #     BUILD_TYPE: Debug
           #     ENABLE_SSL_DYNAMIC_LOADING: YES
           #     OPENSSL_1_0: NO
@@ -313,7 +314,7 @@ jobs:
           - os: macos-latest
             compiler: clang
             env:
-              N: Clang-OSX-Complete-NoLua-Release-OpenSSL_1_1_NoDynLoad
+              NAME: Clang-OSX-Complete-NoLua-Release-OpenSSL_1_1_NoDynLoad
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: NO
               OPENSSL_1_0: NO
@@ -338,7 +339,7 @@ jobs:
           - os: macos-latest
             compiler: clang
             env:
-              N: OSX-Package_OpenSSL_1_1
+              NAME: OSX-Package_OpenSSL_1_1
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO
@@ -364,7 +365,7 @@ jobs:
           - os: macos-latest
             compiler: clang
             env:
-              N: OSX-Package_OpenSSL_3_0
+              NAME: OSX-Package_OpenSSL_3_0
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -16,7 +16,6 @@ jobs:
           - os: ubuntu-latest
             compiler: clang
             env:
-              idx: 1
               N: Clang-Linux-Minimal-Debug
               BUILD_TYPE: Debug
               ENABLE_SSL_DYNAMIC_LOADING: YES
@@ -42,7 +41,6 @@ jobs:
           - os: ubuntu-latest
             compiler: clang
             env:
-              idx: 3
               N: Clang-Linux-Default-Release
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
@@ -68,7 +66,6 @@ jobs:
           - os: ubuntu-latest
             compiler: gcc 
             env:
-              idx: 5
               N: GCC-Linux-Complete-NoLua-Release
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
@@ -94,7 +91,6 @@ jobs:
           - os: ubuntu-latest
             compiler: clang
             env:
-              idx: 6
               N: CLANG-AnyVersion-Linux-Coverage
               BUILD_TYPE: Coverage
               ENABLE_SSL_DYNAMIC_LOADING: YES
@@ -120,7 +116,6 @@ jobs:
           - os: ubuntu-latest
             compiler: clang
             env:
-              idx: 9
               N: Clang-Linux-Default-Shared
               BUILD_TYPE: Debug
               ENABLE_SSL_DYNAMIC_LOADING: YES
@@ -146,7 +141,6 @@ jobs:
           - os: ubuntu-latest
             compiler: gcc
             env:
-              idx: 15
               N: GCCLinuxDefault_RelWithDebInfo
               BUILD_TYPE: RelWithDebInfo
               ENABLE_SSL_DYNAMIC_LOADING: YES
@@ -171,7 +165,6 @@ jobs:
           - os: ubuntu-latest
             compiler: gcc
             env:
-              idx: 16
               N: GCCLinuxDefault_MinSizeRel
               BUILD_TYPE: MinSizeRel
               ENABLE_SSL_DYNAMIC_LOADING: YES
@@ -196,7 +189,6 @@ jobs:
           - os: ubuntu-latest
             compiler: gcc
             env:
-              idx: 17
               N: GCCLinuxDefault_None
               BUILD_TYPE: None
               ENABLE_SSL_DYNAMIC_LOADING: YES
@@ -221,7 +213,6 @@ jobs:
           - os: ubuntu-latest
             compiler: gcc
             env:
-              idx: 20
               N: GCCLinuxDefault_xenial
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
@@ -246,12 +237,36 @@ jobs:
           - os: ubuntu-latest
             compiler: gcc
             env:
-              idx: 23
               N: GCCLinuxDefault_focal
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: NO
               OPENSSL_1_1: YES
+              ENABLE_CXX: NO
+              ENABLE_LUA_SHARED: NO
+              C_STANDARD: auto
+              CXX_STANDARD: auto
+              BUILD_SHARED: NO
+              NO_FILES: NO
+              ENABLE_SSL: YES
+              NO_CGI: NO
+              ENABLE_IPV6: NO
+              ENABLE_WEBSOCKETS: NO
+              ENABLE_LUA: NO
+              ENABLE_DUKTAPE: NO
+              NO_CACHING: NO
+              ALLOW_WARNINGS: YES
+              RUN_UNITTEST: 1
+         
+          - os: ubuntu-latest
+            compiler: gcc
+            env:
+              N: GCCLinuxDefault_OpenSSL_3_0
+              BUILD_TYPE: Release
+              ENABLE_SSL_DYNAMIC_LOADING: YES
+              OPENSSL_1_0: NO
+              OPENSSL_1_1: NO
+              OpenSSL_3_0: YES
               ENABLE_CXX: NO
               ENABLE_LUA_SHARED: NO
               C_STANDARD: auto
@@ -273,7 +288,6 @@ jobs:
           # - os: ubuntu-lastest
           #   compiler: clang
           #   env:
-          #     idx: 99
           #     N: Clang-Linux-Complete-WithLua-Debug
           #     BUILD_TYPE: Debug
           #     ENABLE_SSL_DYNAMIC_LOADING: YES
@@ -299,7 +313,6 @@ jobs:
           - os: macos-latest
             compiler: clang
             env:
-              idx: 8
               N: Clang-OSX-Complete-NoLua-Release-OpenSSL_1_1_NoDynLoad
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: NO
@@ -328,12 +341,38 @@ jobs:
           - os: macos-13
             compiler: clang
             env:
-              idx: 11
-              N: OSX-Package
+              N: OSX-Package_OpenSSL_1_0
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: YES
               OPENSSL_1_0: YES
               OPENSSL_1_1: NO
+              ENABLE_CXX: NO
+              ENABLE_LUA_SHARED: NO
+              C_STANDARD: auto
+              CXX_STANDARD: auto
+              BUILD_SHARED: NO
+              NO_FILES: NO
+              ENABLE_SSL: YES
+              NO_CGI: NO
+              ENABLE_IPV6: YES
+              ENABLE_WEBSOCKETS: YES
+              ENABLE_SERVER_STATS: NO
+              ENABLE_LUA: NO
+              ENABLE_DUKTAPE: NO
+              NO_CACHING: NO
+              ALLOW_WARNINGS: YES
+              MACOSX_PACKAGE: 1
+              RUN_UNITTEST: 1
+
+          - os: macos-latest
+            compiler: clang
+            env:
+              N: OSX-Package_OpenSSL_3_0
+              BUILD_TYPE: Release
+              ENABLE_SSL_DYNAMIC_LOADING: YES
+              OPENSSL_1_0: NO
+              OPENSSL_1_1: NO
+              OPENSSL_3_0: YES
               ENABLE_CXX: NO
               ENABLE_LUA_SHARED: NO
               C_STANDARD: auto
@@ -404,7 +443,25 @@ jobs:
             echo "${OPENSSL_ROOT_DIR}/bin" >> $GITHUB_PATH
             echo "ADDITIONAL_CMAKE_ARGS=${ADDITIONAL_CMAKE_ARGS}" >> $GITHUB_ENV
             echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> $GITHUB_ENV
+
+        - name: Install OpenSSL 3.0 on modern MacOS
+          # OpenSSL 1.1 is installed by default, so we need to install 3.0 manually
+          if: startsWith(matrix.os,'macos') && matrix.env.OPENSSL_3_0 == 'YES'            
+          run: |
+            brew install openssl@3.0
             
+            OPENSSL_ROOT_DIR=$(brew --prefix openssl@3.0)
+            LDFLAGS=-L${OPENSSL_ROOT_DIR}/lib
+            CFLAGS=-I${OPENSSL_ROOT_DIR}/include
+            ADDITIONAL_CMAKE_ARGS="-DCMAKE_SHARED_LINKER_FLAGS=${LDFLAGS} -DMAKE_C_FLAGS=${CFLAGS}"
+            PKG_CONFIG_PATH=${OPENSSL_ROOT_DIR}/lib/pkgconfig
+
+            echo "LDFLAGS=${LDFLAGS}" >> $GITHUB_ENV
+            echo "CFLAGS=${CFLAGS}" >> $GITHUB_ENV
+            echo "${OPENSSL_ROOT_DIR}/bin" >> $GITHUB_PATH
+            echo "ADDITIONAL_CMAKE_ARGS=${ADDITIONAL_CMAKE_ARGS}" >> $GITHUB_ENV
+            echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> $GITHUB_ENV
+
         - name: Install OpenSSL 1.0 on modern Linux
           # Needed for recent versions of Linux as they ship with OpenSSL 3.0 by default
           if: startsWith(matrix.os,'ubuntu') && matrix.env.OPENSSL_1_0 == 'YES'

--- a/unittest/public_server.c
+++ b/unittest/public_server.c
@@ -823,7 +823,7 @@ START_TEST(test_mg_server_and_client_tls)
 	 * while Ubuntu Xenial, Ubuntu Trusty and Windows test containers at
 	 * Travis CI do not. Maybe it is OpenSSL version specific.
 	 */
-#if defined(OPENSSL_API_1_1)
+#if defined(OPENSSL_API_1_1) || defined(OPENSSL_API_3_0) 
 	if (client_conn) {
 		/* Connect succeeds, but the connection is unusable. */
 		mg_printf(client_conn, "GET / HTTP/1.0\r\n\r\n");


### PR DESCRIPTION
I've added 2 tests using OpenSSL3.0 - one for Linux, one for macOS.
I also decided to drop OpenSSL1.0 tests - it's EOL since 2019 (!) and should not be used anymore. (The same is true of OpenSSL 1.1, but I did not want to go that far).