### PR TITLE
#1147 Load version-specific libcrypto and libssl shared libraries

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -907,8 +907,22 @@ typedef unsigned short int in_port_t;
 #endif
 
 #if defined(__MACH__) && defined(__APPLE__)
-#define SSL_LIB "libssl.dylib"
-#define CRYPTO_LIB "libcrypto.dylib"
+
+#if defined(OPENSSL_API_3_0)
+#define SSL_LIB "libssl.3.dylib"
+#define CRYPTO_LIB "libcrypto.3.dylib"
+#endif
+
+#if defined(OPENSSL_API_1_1)
+#define SSL_LIB "libssl.1.1.dylib"
+#define CRYPTO_LIB "libcrypto.1.1.dylib"
+#endif /* OPENSSL_API_1_1 */
+
+#if defined(OPENSSL_API_1_0)
+#define SSL_LIB "libssl.1.0.dylib"
+#define CRYPTO_LIB "libcrypto.1.0.dylib"
+#endif /* OPENSSL_API_1_0 */
+
 #else
 #if !defined(SSL_LIB)
 #define SSL_LIB "libssl.so"


### PR DESCRIPTION
See [original issue](https://github.com/civetweb/civetweb/issues/1147).

From [OS X 11.1 and up](https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-release-notes#Kernel), OS X provides a cache of `dylib` files, including a `libcrypto.dylib` shim that, unfortunately, yields a warning and an implicit `abort` call on loading. See dummy test using `lldb`:
```console
> cat dltest.c
#include <dlfcn.h>

int main(void) {
}
> make dltest
make: `dltest' is up to date.
> lldb dltest
(lldb) target create "dltest"
Current executable set to '/var/tmp/dltest/dltest' (arm64).
(lldb) b main
Breakpoint 1: where = dltest`main, address = 0x0000000100003fa0
(lldb) r
Process 52476 launched: '/var/tmp/dltest/dltest' (arm64)
Process 52476 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
    frame #0: 0x0000000100003fa0 dltest`main
dltest`main:
->  0x100003fa0 <+0>: mov    w0, #0x0 ; =0
    0x100003fa4 <+4>: ret
    0x100003fa8:      udf    #0x1
    0x100003fac:      udf    #0x1c
Target 0: (dltest) stopped.
(lldb) p (void*)dlopen("libcrypto.dylib")
WARNING: /var/tmp/dltest/dltest is loading libcrypto in an unsafe way
error: Execution was interrupted, reason: signal SIGABRT.
```

This PR changes the `#define` logic to favor a versioned shared library as target of `dlopen`.
This will avoid a `SIGABORT` in the scenario where a versioned symlink is not found in the `DYLD_LIBRARY_PATH`.