### PR TITLE
Bump minimum CMake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
-# Use at least CMake 3.3
-cmake_minimum_required (VERSION 3.3.0)
-cmake_policy(VERSION 3.2.2)
-cmake_policy(SET CMP0054 NEW)
-cmake_policy(SET CMP0057 NEW)
+cmake_minimum_required(VERSION 3.10)
+cmake_policy(VERSION 3.10)
 
 # Set up the project
 project (civetweb VERSION 1.16.0)

--- a/examples/linux_ws_server_cpp/CMakeLists.txt
+++ b/examples/linux_ws_server_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.10)
 project(linux_ws_server)
 
 set(TARGET_NAME ${PROJECT_NAME})


### PR DESCRIPTION
So that there are no [deprecation warnings](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-settings) on the latest CMake.