### PR TITLE
Export ports.is_optional

### DIFF
--- a/docs/api/mg_server_port.md
+++ b/docs/api/mg_server_port.md
@@ -10,7 +10,7 @@
 |**`port`**|`int`|The port number on which the service listens|
 |**`is_ssl`**|`int`|**0** for `HTTP` communication, **1** for `HTTPS`|
 |**`is_redirect`**|`int`|**1** if all requests are redirected, otherwise **0**|
-|**`_reserved1`**|`int`|Reserved for internal use|
+|**`is_optional`**|`int`|**1** if prot is optional, otherwise **0**|
 |**`_reserved2`**|`int`|Reserved for internal use|
 |**`_reserved3`**|`int`|Reserved for internal use|
 |**`_reserved4`**|`int`|Reserved for internal use|

--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -714,7 +714,7 @@ struct mg_server_port {
 	int port;        /* port number */
 	int is_ssl;      /* https port: 0 = no, 1 = yes */
 	int is_redirect; /* redirect all requests: 0 = no, 1 = yes */
-	int _reserved1;
+	int is_optional; /* optional: 0 = no, 1 = yes */
 	int _reserved2;
 	int _reserved3;
 	int _reserved4;

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -3337,6 +3337,7 @@ mg_get_server_ports(const struct mg_context *ctx,
 		    ntohs(USA_IN_PORT_UNSAFE(&(ctx->listening_sockets[i].lsa)));
 		ports[cnt].is_ssl = ctx->listening_sockets[i].is_ssl;
 		ports[cnt].is_redirect = ctx->listening_sockets[i].ssl_redir;
+		ports[cnt].is_optional = ctx->listening_sockets[i].is_optional;
 
 		if (ctx->listening_sockets[i].lsa.sa.sa_family == AF_INET) {
 			/* IPv4 */

--- a/unittest/public_server.c
+++ b/unittest/public_server.c
@@ -457,10 +457,12 @@ test_mg_start_stop_http_server_impl(int ipv6, int bound)
 	ck_assert_int_eq(portinfo[0].port, 0);
 	ck_assert_int_eq(portinfo[0].is_ssl, 0);
 	ck_assert_int_eq(portinfo[0].is_redirect, 0);
+	ck_assert_int_eq(portinfo[0].is_optional, 0);
 	ck_assert_int_eq(portinfo[1].protocol, 0);
 	ck_assert_int_eq(portinfo[1].port, 0);
 	ck_assert_int_eq(portinfo[1].is_ssl, 0);
 	ck_assert_int_eq(portinfo[1].is_redirect, 0);
+	ck_assert_int_eq(portinfo[1].is_optional, 0);
 
 	ret = mg_get_server_ports(ctx, 4, portinfo);
 	ck_assert_int_eq(ret, 1);
@@ -472,10 +474,12 @@ test_mg_start_stop_http_server_impl(int ipv6, int bound)
 	ck_assert_int_eq(portinfo[0].port, 8080);
 	ck_assert_int_eq(portinfo[0].is_ssl, 0);
 	ck_assert_int_eq(portinfo[0].is_redirect, 0);
+	ck_assert_int_eq(portinfo[0].is_optional, 0);
 	ck_assert_int_eq(portinfo[1].protocol, 0);
 	ck_assert_int_eq(portinfo[1].port, 0);
 	ck_assert_int_eq(portinfo[1].is_ssl, 0);
 	ck_assert_int_eq(portinfo[1].is_redirect, 0);
+	ck_assert_int_eq(portinfo[1].is_optional, 0);
 
 	test_sleep(1);
 
@@ -649,7 +653,7 @@ START_TEST(test_mg_start_stop_https_server)
 	OPTIONS[opt_idx++] = ".";
 #endif
 	OPTIONS[opt_idx++] = "listening_ports";
-	OPTIONS[opt_idx++] = "8080r,8443s";
+	OPTIONS[opt_idx++] = "8080r,8443os";
 	OPTIONS[opt_idx++] = "ssl_certificate";
 	OPTIONS[opt_idx++] = ssl_cert;
 
@@ -674,10 +678,12 @@ START_TEST(test_mg_start_stop_https_server)
 	ck_assert_int_eq(portinfo[0].port, 0);
 	ck_assert_int_eq(portinfo[0].is_ssl, 0);
 	ck_assert_int_eq(portinfo[0].is_redirect, 0);
+	ck_assert_int_eq(portinfo[0].is_optional, 0);
 	ck_assert_int_eq(portinfo[1].protocol, 0);
 	ck_assert_int_eq(portinfo[1].port, 0);
 	ck_assert_int_eq(portinfo[1].is_ssl, 0);
 	ck_assert_int_eq(portinfo[1].is_redirect, 0);
+	ck_assert_int_eq(portinfo[1].is_optional, 0);
 
 	ret = mg_get_server_ports(ctx, 4, portinfo);
 	ck_assert_int_eq(ret, 2);
@@ -685,14 +691,17 @@ START_TEST(test_mg_start_stop_https_server)
 	ck_assert_int_eq(portinfo[0].port, 8080);
 	ck_assert_int_eq(portinfo[0].is_ssl, 0);
 	ck_assert_int_eq(portinfo[0].is_redirect, 1);
+	ck_assert_int_eq(portinfo[0].is_optional, 0);
 	ck_assert_int_eq(portinfo[1].protocol, 1);
 	ck_assert_int_eq(portinfo[1].port, 8443);
 	ck_assert_int_eq(portinfo[1].is_ssl, 1);
 	ck_assert_int_eq(portinfo[1].is_redirect, 0);
+	ck_assert_int_eq(portinfo[1].is_optional, 1);
 	ck_assert_int_eq(portinfo[2].protocol, 0);
 	ck_assert_int_eq(portinfo[2].port, 0);
 	ck_assert_int_eq(portinfo[2].is_ssl, 0);
 	ck_assert_int_eq(portinfo[2].is_redirect, 0);
+	ck_assert_int_eq(portinfo[2].is_optional, 0);
 
 	test_sleep(1);
 
@@ -771,7 +780,7 @@ START_TEST(test_mg_server_and_client_tls)
 	OPTIONS[opt_idx++] = ".";
 #endif
 	OPTIONS[opt_idx++] = "listening_ports";
-	OPTIONS[opt_idx++] = "8080r,8443s";
+	OPTIONS[opt_idx++] = "8080r,8443os";
 	OPTIONS[opt_idx++] = "ssl_certificate";
 	OPTIONS[opt_idx++] = server_cert;
 	OPTIONS[opt_idx++] = "ssl_verify_peer";
@@ -800,14 +809,17 @@ START_TEST(test_mg_server_and_client_tls)
 	ck_assert_int_eq(ports[0].port, 8080);
 	ck_assert_int_eq(ports[0].is_ssl, 0);
 	ck_assert_int_eq(ports[0].is_redirect, 1);
+	ck_assert_int_eq(ports[0].is_optional, 0);
 	ck_assert_int_eq(ports[1].protocol, 1);
 	ck_assert_int_eq(ports[1].port, 8443);
 	ck_assert_int_eq(ports[1].is_ssl, 1);
 	ck_assert_int_eq(ports[1].is_redirect, 0);
+	ck_assert_int_eq(ports[1].is_optional, 1);
 	ck_assert_int_eq(ports[2].protocol, 0);
 	ck_assert_int_eq(ports[2].port, 0);
 	ck_assert_int_eq(ports[2].is_ssl, 0);
 	ck_assert_int_eq(ports[2].is_redirect, 0);
+	ck_assert_int_eq(ports[2].is_optional, 0);
 
 	test_sleep(1);
 


### PR DESCRIPTION
Expose is_optional property of `listening_ports` via `mg_get_server_ports()`

This PR picks up what was forgotten in https://github.com/civetweb/civetweb/pull/1186