### PR TITLE
Expose if server ports are bound

### DIFF
--- a/docs/api/mg_server_port.md
+++ b/docs/api/mg_server_port.md
@@ -10,8 +10,8 @@
 |**`port`**|`int`|The port number on which the service listens|
 |**`is_ssl`**|`int`|**0** for `HTTP` communication, **1** for `HTTPS`|
 |**`is_redirect`**|`int`|**1** if all requests are redirected, otherwise **0**|
-|**`is_optional`**|`int`|**1** if prot is optional, otherwise **0**|
-|**`_reserved2`**|`int`|Reserved for internal use|
+|**`is_optional`**|`int`|**1** if port is optional, otherwise **0**|
+|**`is_bound`**|`int`|**1** if the port is bound, otherwise **0**|
 |**`_reserved3`**|`int`|Reserved for internal use|
 |**`_reserved4`**|`int`|Reserved for internal use|
 

--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -715,7 +715,7 @@ struct mg_server_port {
 	int is_ssl;      /* https port: 0 = no, 1 = yes */
 	int is_redirect; /* redirect all requests: 0 = no, 1 = yes */
 	int is_optional; /* optional: 0 = no, 1 = yes */
-	int _reserved2;
+	int is_bound;    /* bound: 0 = no, 1 = yes, relevant for optional ports */
 	int _reserved3;
 	int _reserved4;
 };

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -3338,6 +3338,7 @@ mg_get_server_ports(const struct mg_context *ctx,
 		ports[cnt].is_ssl = ctx->listening_sockets[i].is_ssl;
 		ports[cnt].is_redirect = ctx->listening_sockets[i].ssl_redir;
 		ports[cnt].is_optional = ctx->listening_sockets[i].is_optional;
+		ports[cnt].is_bound = ctx->listening_sockets[i].sock != INVALID_SOCKET;
 
 		if (ctx->listening_sockets[i].lsa.sa.sa_family == AF_INET) {
 			/* IPv4 */

--- a/unittest/public_server.c
+++ b/unittest/public_server.c
@@ -458,11 +458,13 @@ test_mg_start_stop_http_server_impl(int ipv6, int bound)
 	ck_assert_int_eq(portinfo[0].is_ssl, 0);
 	ck_assert_int_eq(portinfo[0].is_redirect, 0);
 	ck_assert_int_eq(portinfo[0].is_optional, 0);
+	ck_assert_int_eq(portinfo[0].is_bound, 0);
 	ck_assert_int_eq(portinfo[1].protocol, 0);
 	ck_assert_int_eq(portinfo[1].port, 0);
 	ck_assert_int_eq(portinfo[1].is_ssl, 0);
 	ck_assert_int_eq(portinfo[1].is_redirect, 0);
 	ck_assert_int_eq(portinfo[1].is_optional, 0);
+	ck_assert_int_eq(portinfo[1].is_bound, 0);
 
 	ret = mg_get_server_ports(ctx, 4, portinfo);
 	ck_assert_int_eq(ret, 1);
@@ -475,11 +477,13 @@ test_mg_start_stop_http_server_impl(int ipv6, int bound)
 	ck_assert_int_eq(portinfo[0].is_ssl, 0);
 	ck_assert_int_eq(portinfo[0].is_redirect, 0);
 	ck_assert_int_eq(portinfo[0].is_optional, 0);
+	ck_assert_int_eq(portinfo[0].is_bound, 1);
 	ck_assert_int_eq(portinfo[1].protocol, 0);
 	ck_assert_int_eq(portinfo[1].port, 0);
 	ck_assert_int_eq(portinfo[1].is_ssl, 0);
 	ck_assert_int_eq(portinfo[1].is_redirect, 0);
 	ck_assert_int_eq(portinfo[1].is_optional, 0);
+	ck_assert_int_eq(portinfo[1].is_bound, 0);
 
 	test_sleep(1);
 
@@ -679,11 +683,13 @@ START_TEST(test_mg_start_stop_https_server)
 	ck_assert_int_eq(portinfo[0].is_ssl, 0);
 	ck_assert_int_eq(portinfo[0].is_redirect, 0);
 	ck_assert_int_eq(portinfo[0].is_optional, 0);
+	ck_assert_int_eq(portinfo[0].is_bound, 0);
 	ck_assert_int_eq(portinfo[1].protocol, 0);
 	ck_assert_int_eq(portinfo[1].port, 0);
 	ck_assert_int_eq(portinfo[1].is_ssl, 0);
 	ck_assert_int_eq(portinfo[1].is_redirect, 0);
 	ck_assert_int_eq(portinfo[1].is_optional, 0);
+	ck_assert_int_eq(portinfo[1].is_bound, 0);
 
 	ret = mg_get_server_ports(ctx, 4, portinfo);
 	ck_assert_int_eq(ret, 2);
@@ -692,16 +698,19 @@ START_TEST(test_mg_start_stop_https_server)
 	ck_assert_int_eq(portinfo[0].is_ssl, 0);
 	ck_assert_int_eq(portinfo[0].is_redirect, 1);
 	ck_assert_int_eq(portinfo[0].is_optional, 0);
+	ck_assert_int_eq(portinfo[0].is_bound, 1);
 	ck_assert_int_eq(portinfo[1].protocol, 1);
 	ck_assert_int_eq(portinfo[1].port, 8443);
 	ck_assert_int_eq(portinfo[1].is_ssl, 1);
 	ck_assert_int_eq(portinfo[1].is_redirect, 0);
 	ck_assert_int_eq(portinfo[1].is_optional, 1);
+	ck_assert_int_eq(portinfo[1].is_bound, 1);
 	ck_assert_int_eq(portinfo[2].protocol, 0);
 	ck_assert_int_eq(portinfo[2].port, 0);
 	ck_assert_int_eq(portinfo[2].is_ssl, 0);
 	ck_assert_int_eq(portinfo[2].is_redirect, 0);
 	ck_assert_int_eq(portinfo[2].is_optional, 0);
+	ck_assert_int_eq(portinfo[2].is_bound, 0);
 
 	test_sleep(1);
 
@@ -810,16 +819,19 @@ START_TEST(test_mg_server_and_client_tls)
 	ck_assert_int_eq(ports[0].is_ssl, 0);
 	ck_assert_int_eq(ports[0].is_redirect, 1);
 	ck_assert_int_eq(ports[0].is_optional, 0);
+	ck_assert_int_eq(ports[0].is_bound, 1);
 	ck_assert_int_eq(ports[1].protocol, 1);
 	ck_assert_int_eq(ports[1].port, 8443);
 	ck_assert_int_eq(ports[1].is_ssl, 1);
 	ck_assert_int_eq(ports[1].is_redirect, 0);
 	ck_assert_int_eq(ports[1].is_optional, 1);
+	ck_assert_int_eq(ports[1].is_bound, 1);
 	ck_assert_int_eq(ports[2].protocol, 0);
 	ck_assert_int_eq(ports[2].port, 0);
 	ck_assert_int_eq(ports[2].is_ssl, 0);
 	ck_assert_int_eq(ports[2].is_redirect, 0);
 	ck_assert_int_eq(ports[2].is_optional, 0);
+	ck_assert_int_eq(ports[2].is_bound, 0);
 
 	test_sleep(1);
 


### PR DESCRIPTION
There is no other way to know if binding to ports has succeeded. This is meaningful in the context of optional ports to check if the webserver is actually available on this port or not.