### PR TITLE
 Prevent crash on no bound ports

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -20542,7 +20542,7 @@ master_thread_run(struct mg_context *ctx)
 	unsigned int i;
 	unsigned int workerthreadcount;
 
-	if (!ctx) {
+	if (!ctx || !ctx->listening_socket_fds) {
 		return;
 	}
 


### PR DESCRIPTION
Terminate master_thread early when there are no listening sockets to prevent CivetWeb from crashing.

Fixes #1327 