### PR TITLE
Add X509 certificate and CRL MIME-types

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -8511,6 +8511,9 @@ static const struct {
      * (http://www.iana.org/assignments/media-types)
      * application types */
     {".bin", 4, "application/octet-stream"},
+    {".cer", 4, "application/pkix-cert"},
+    {".crl", 4, "application/pkix-crl"},
+    {".crt", 4, "application/pkix-cert"},
     {".deb", 4, "application/octet-stream"},
     {".dmg", 4, "application/octet-stream"},
     {".dll", 4, "application/octet-stream"},
@@ -8522,6 +8525,7 @@ static const struct {
     {".json", 5, "application/json"},
     {".mjs", 4, "application/javascript"},
     {".msi", 4, "application/octet-stream"},
+    {".pem", 4, "application/x-pem-file"},
     {".pdf", 4, "application/pdf"},
     {".ps", 3, "application/postscript"},
     {".rtf", 4, "application/rtf"},


### PR DESCRIPTION
Currently civetweb recognizes only a very limited number of MIME types.
While I'm sure the list may be extended significantly I'd like to contribute the MIME types that are commonly used to serve certificate (.crt, .cer) and CRL files (.crl).
Current behaviour is to serve certificate/CRL files with the default civetweb MIME type of "text/plain" which prevents browsers to correctly identify the served files.

See: [RFC-2585](https://datatracker.ietf.org/doc/html/rfc2585#section-4)

Add the following MIME types:
- application/pkix-cert
- application/pkix-crl
- application/x-pem-file