### PR TITLE
Tolerate socket creation error if port is optional

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -16154,6 +16154,10 @@ set_ports_option(struct mg_context *phys_ctx)
 			mg_cry_ctx_internal(phys_ctx,
 			                    "cannot create socket (entry %i)",
 			                    portsTotal);
+			if (so.is_optional) {
+				portsOk++; /* it's okay if we couldn't create a socket,
+						this port is optional anyway */
+			}
 			continue;
 		}
 
@@ -16239,6 +16243,10 @@ set_ports_option(struct mg_context *phys_ctx)
 #else
 			mg_cry_ctx_internal(phys_ctx, "%s", "IPv6 not available");
 			closesocket(so.sock);
+			if (so.is_optional) {
+				portsOk++; /* it's okay if we couldn't set the socket option,
+				              this port is optional anyway */
+			}
 			so.sock = INVALID_SOCKET;
 			continue;
 #endif


### PR DESCRIPTION
When users specify `[::]:80o` as port but the system has IPv6 disabled globally, e.g., with
```
GRUB_CMDLINE_LINUX="ipv6.disable=1"
```
then CivetWeb refuses to start even though it should skip the port if it cannot bind to it. However, when the port is specified as being optional, there is no point in treating non-availability of the protocol differently than the port already being taken. In this case, this port should simply be skipped.