### PR TITLE
Use the correct Markdown syntax in page titles

### DIFF
--- a/docs/OpenSSL.md
+++ b/docs/OpenSSL.md
@@ -1,5 +1,4 @@
-Adding OpenSSL Support
-=====
+# Adding OpenSSL Support
 
 Civetweb supports *HTTPS* connections using the OpenSSL transport layer
 security (TLS) library. OpenSSL is a free, open source library (see

--- a/docs/gnutls.md
+++ b/docs/gnutls.md
@@ -1,5 +1,4 @@
-#### Use GnuTLS instead of OpenSSL
-=====
+# Use GnuTLS instead of OpenSSL
 
 1 [Build libgmp](https://gmplib.org)
 


### PR DESCRIPTION
fixed in 2 files