### PR TITLE
Prevent CRLF injection attempts

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -18858,6 +18858,19 @@ get_uri_type(const char *uri)
 	 * and % encoded symbols.
 	 */
 	for (i = 0; uri[i] != 0; i++) {
+		/* Check for CRLF injection attempts */
+		if (uri[i] == '%') {
+			if (uri[i+1] == '0' && (uri[i+2] == 'd' || uri[i+2] == 'D')) {
+				/* Found %0d (CR) */
+				DEBUG_TRACE("CRLF injection attempt detected: %s\r\n", uri);
+				return 0;
+			}
+			if (uri[i+1] == '0' && (uri[i+2] == 'a' || uri[i+2] == 'A')) {
+				/* Found %0a (LF) */
+				DEBUG_TRACE("CRLF injection attempt detected: %s\r\n", uri);
+				return 0;
+			}
+		}
 		if ((unsigned char)uri[i] < 33) {
 			/* control characters and spaces are invalid */
 			return 0;


### PR DESCRIPTION
Currently, `civetweb` is susceptible for Carriage Return Line Feed (CRLF) Injection as it does not reject URI's with CR or LF. So an attacker could abuse this and e.g. set cookies by

http://IP/index%0d%0aSet-Cookie:%20sid=INFECTED.html