### PR TITLE
Fix heap overflow in directory URI redirection

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -15596,14 +15596,14 @@ handle_request(struct mg_connection *conn)
 			if (len + 1 < buflen) {
 				new_path[len] = '/';
 				new_path[len + 1] = '\0';
-				len += 1;
+				len++;
 			}
 
 			if (ri->query_string) {
 				if (len + 1 < buflen) {
 					new_path[len] = '?';
 					new_path[len + 1] = '\0';
-					len += 1;
+					len++;
 				}
 
 				/* Append with size of space left for query string + null terminator */

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -15579,7 +15579,6 @@ handle_request(struct mg_connection *conn)
 	/* 12. Directory uris should end with a slash */
 	if (file.stat.is_directory && ((uri_len = (int)strlen(ri->local_uri)) > 0)
 	    && (ri->local_uri[uri_len - 1] != '/')) {
-
 		/* Path + server root */
 		size_t buflen = UTF8_PATH_MAX * 2 + 2;
 		char *new_path;
@@ -15592,12 +15591,26 @@ handle_request(struct mg_connection *conn)
 			mg_send_http_error(conn, 500, "out or memory");
 		} else {
 			mg_get_request_link(conn, new_path, buflen - 1);
-			strcat(new_path, "/");
-			if (ri->query_string) {
-				/* Append ? and query string */
-				strcat(new_path, "?");
-				strcat(new_path, ri->query_string);
+
+			size_t len = strlen(new_path);
+			if (len + 1 < buflen) {
+				new_path[len] = '/';
+				new_path[len + 1] = '\0';
+				len += 1;
 			}
+
+			if (ri->query_string) {
+				if (len + 1 < buflen) {
+					new_path[len] = '?';
+					new_path[len + 1] = '\0';
+					len += 1;
+				}
+
+				/* Append with size of space left for query string + null terminator */
+				size_t max_append = buflen - len - 1;
+				strncat(new_path, ri->query_string, max_append);
+			}
+
 			mg_send_http_redirect(conn, new_path, 301);
 			mg_free(new_path);
 		}


### PR DESCRIPTION
This pull request addresses a heap buffer overflow vulnerability in the directory URI redirection logic in `handle_request()` (refer to issue #1346)

The patch replaces unsafe `strcat` usage with `strncat` to ensure that no more than `buflen - 1` bytes are written to the buffer.

I have ran the full unit tests script `unittest/build_and_test_full.sh` for this patch - no new test failures appear with this patch compared to the base repository.

I appreciate feedback in case I have missed anything.