### PR TITLE
Fixed typos where CivetWeb was spelled Incorrectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ CivetWeb is based on the [Mongoose project](https://github.com/cesanta/mongoose)
 Sergey Lyubka(2004-2013) who released it under the MIT license.
 However, on August 16, 2013,
 [Mongoose was relicensed to a dual GPL V2 + commercial license](https://groups.google.com/forum/#!topic/mongoose-users/aafbOnHonkI)
-and CiwetWeb was created by Thomas Davis (sunsetbrew) as "the MIT fork of mongoose".
+and CivetWeb was created by Thomas Davis (sunsetbrew) as "the MIT fork of mongoose".
 The license change and CivetWeb fork was mentioned on the Mongoose
 [Wikipedia](https://en.wikipedia.org/wiki/Mongoose_(web_server))
 page as well, but it's getting deleted (and added again) there every

--- a/test/page4.lp
+++ b/test/page4.lp
@@ -22,10 +22,10 @@ the "Kepler syntax" uses <code>&lt;?lua chunk ?&gt;</code>, <code>&lt;?lua= expr
 <h2>Tags</h2>
 
 <code>
-&lt;? greeting = 'CiwetWeb' ?&gt;<br/>
+&lt;? greeting = 'CivetWeb' ?&gt;<br/>
 &lt;strong&gt;&lt;?= greeting %&gt;&lt;/strong&gt;<br/>
 </code><br/>
-<? greeting = 'CiwetWeb' ?>
+<? greeting = 'CivetWeb' ?>
 ==> <strong><?= greeting ?></strong><br/>
 
 <br/>

--- a/test/page4kepler.lp
+++ b/test/page4kepler.lp
@@ -19,10 +19,10 @@ the "Kepler syntax" uses <code>&lt;?lua chunk ?&gt;</code>, <code>&lt;?lua= expr
 <h2>Tags</h2>
 
 <code>
-&lt;? greeting = 'CiwetWeb' ?&gt;<br/>
+&lt;? greeting = 'CivetWeb' ?&gt;<br/>
 &lt;strong&gt;&lt;?= greeting %&gt;&lt;/strong&gt;<br/>
 </code><br/>
-<? greeting = 'CiwetWeb' ?>
+<? greeting = 'CivetWeb' ?>
 ==> <strong><?= greeting ?></strong><br/>
 
 <br/>


### PR DESCRIPTION
In various places, CivetWeb was spelled CiwetWeb, a possible typo.  This pull request fixes these typos.