### PR TITLE
Feature/replace asterisk with origin

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -4235,15 +4235,15 @@ send_cors_header(struct mg_connection *conn)
 	    conn->dom_ctx->config[ACCESS_CONTROL_EXPOSE_HEADERS];
 	const char *cors_meth_cfg =
 	    conn->dom_ctx->config[ACCESS_CONTROL_ALLOW_METHODS];
-
-	int cors_replace_asterisk_with_origin = mg_strcasecmp(conn->dom_ctx->config[REPLACE_ASTERISK_WITH_ORIGIN], "yes");
 		
 	if (cors_orig_cfg && *cors_orig_cfg && origin_hdr && *origin_hdr) {
+		int cors_repla_asterisk_with_orig_cfg = mg_strcasecmp(conn->dom_ctx->config[REPLACE_ASTERISK_WITH_ORIGIN], "yes");
+		
 		/* Cross-origin resource sharing (CORS), see
 		 * http://www.html5rocks.com/en/tutorials/cors/,
 		 * http://www.html5rocks.com/static/images/cors_server_flowchart.png
 		 * CORS preflight is not supported for files. */
-		if (cors_replace_asterisk_with_origin == 0 && cors_orig_cfg[0] == '*') {
+		if (cors_repla_asterisk_with_orig_cfg == 0 && cors_orig_cfg[0] == '*') {
 			mg_response_header_add(conn,
 		                       "Access-Control-Allow-Origin",
 		                       origin_hdr,
@@ -15169,14 +15169,14 @@ handle_request(struct mg_connection *conn)
 		const char *cors_acrm = get_header(ri->http_headers,
 		                                   ri->num_headers,
 		                                   "Access-Control-Request-Method");
-		int cors_replace_asterisk_with_origin = mg_strcasecmp(conn->dom_ctx->config[REPLACE_ASTERISK_WITH_ORIGIN], "yes");
-
 		/* Todo: check if cors_origin is in cors_orig_cfg.
 		 * Or, let the client check this. */
 
 		if ((cors_meth_cfg != NULL) && (*cors_meth_cfg != 0)
 		    && (cors_orig_cfg != NULL) && (*cors_orig_cfg != 0)
 		    && (cors_origin != NULL) && (cors_acrm != NULL)) {
+			int cors_repla_asterisk_with_orig_cfg = mg_strcasecmp(conn->dom_ctx->config[REPLACE_ASTERISK_WITH_ORIGIN], "yes");
+			
 			/* This is a valid CORS preflight, and the server is configured
 			 * to handle it automatically. */
 			const char *cors_acrh =
@@ -15197,7 +15197,7 @@ handle_request(struct mg_connection *conn)
 			          "Content-Length: 0\r\n"
 			          "Connection: %s\r\n",
 			          date,
-			          (cors_replace_asterisk_with_origin == 0 && cors_orig_cfg[0] == '*') ? cors_origin : cors_orig_cfg,
+			          (cors_repla_asterisk_with_orig_cfg == 0 && cors_orig_cfg[0] == '*') ? cors_origin : cors_orig_cfg,
 			          ((cors_meth_cfg[0] == '*') ? cors_acrm : cors_meth_cfg),
 			          suggest_connection_header(conn));
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -239,7 +239,7 @@ static void DEBUG_TRACE_FUNC(const char *func,
 
 #define NEED_DEBUG_TRACE_FUNC
 #if !defined(DEBUG_TRACE_STREAM)
-#define DEBUG_TRACE_STREAM stdout
+#define DEBUG_TRACE_STREAM stderr
 #endif
 
 #else
@@ -2146,6 +2146,7 @@ static const struct mg_option config_options[] = {
 #if defined(USE_HTTP2)
     {"enable_http2", MG_CONFIG_TYPE_BOOLEAN, "no"},
 #endif
+
     /* Once for each domain */
     {"document_root", MG_CONFIG_TYPE_DIRECTORY, NULL},
     {"fallback_document_root", MG_CONFIG_TYPE_DIRECTORY, NULL},
@@ -3482,7 +3483,7 @@ mg_cry_internal_impl(const struct mg_connection *conn,
 	DEBUG_TRACE("mg_cry called from %s:%u: %s", func, line, buf);
 
 	if (!conn) {
-		puts(buf);
+		fputs(buf, stderr);
 		return;
 	}
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -4237,13 +4237,13 @@ send_cors_header(struct mg_connection *conn)
 	    conn->dom_ctx->config[ACCESS_CONTROL_ALLOW_METHODS];
 		
 	if (cors_orig_cfg && *cors_orig_cfg && origin_hdr && *origin_hdr) {
-		int cors_repla_asterisk_with_orig_cfg = mg_strcasecmp(conn->dom_ctx->config[REPLACE_ASTERISK_WITH_ORIGIN], "yes");
+		int cors_repl_asterisk_with_orig_cfg = mg_strcasecmp(conn->dom_ctx->config[REPLACE_ASTERISK_WITH_ORIGIN], "yes");
 		
 		/* Cross-origin resource sharing (CORS), see
 		 * http://www.html5rocks.com/en/tutorials/cors/,
 		 * http://www.html5rocks.com/static/images/cors_server_flowchart.png
 		 * CORS preflight is not supported for files. */
-		if (cors_repla_asterisk_with_orig_cfg == 0 && cors_orig_cfg[0] == '*') {
+		if (cors_repl_asterisk_with_orig_cfg == 0 && cors_orig_cfg[0] == '*') {
 			mg_response_header_add(conn,
 		                       "Access-Control-Allow-Origin",
 		                       origin_hdr,
@@ -15175,7 +15175,7 @@ handle_request(struct mg_connection *conn)
 		if ((cors_meth_cfg != NULL) && (*cors_meth_cfg != 0)
 		    && (cors_orig_cfg != NULL) && (*cors_orig_cfg != 0)
 		    && (cors_origin != NULL) && (cors_acrm != NULL)) {
-			int cors_repla_asterisk_with_orig_cfg = mg_strcasecmp(conn->dom_ctx->config[REPLACE_ASTERISK_WITH_ORIGIN], "yes");
+			int cors_repl_asterisk_with_orig_cfg = mg_strcasecmp(conn->dom_ctx->config[REPLACE_ASTERISK_WITH_ORIGIN], "yes");
 			
 			/* This is a valid CORS preflight, and the server is configured
 			 * to handle it automatically. */
@@ -15197,7 +15197,7 @@ handle_request(struct mg_connection *conn)
 			          "Content-Length: 0\r\n"
 			          "Connection: %s\r\n",
 			          date,
-			          (cors_repla_asterisk_with_orig_cfg == 0 && cors_orig_cfg[0] == '*') ? cors_origin : cors_orig_cfg,
+			          (cors_repl_asterisk_with_orig_cfg == 0 && cors_orig_cfg[0] == '*') ? cors_origin : cors_orig_cfg,
 			          ((cors_meth_cfg[0] == '*') ? cors_acrm : cors_meth_cfg),
 			          suggest_connection_header(conn));
 


### PR DESCRIPTION
## Adds replace_asterisk_with_origin option for Acces-Control-Allow-Origin:

If you have multiple allowed origins and require `Access-Control-Allow-Credentials` to be true, CORS might be a problem since it blocks all requests with Allow-Origin "*" in combination with Credentials.  Therefore this feature adds a config paramter `replace_asterisk_with_origin`: 

If it is set to `yes` and the passed `Access-Control-Allow-Origin` is an asterisk, it will be replaced by the origin of the request in the corresponding response to mirror it. This could also be handled inside a request handler, but PREFLIGHTS of the browser failed for me and did not reach the request handler at all. Thats why I added this feature to our civetweb and would like to share it.

### Example usage:

```
const char *options[] = {
        "access_control_allow_origin", "*",
        "access_control_allow_credentials", "true",
        "replace_asterisk_with_origin", "yes",
        "listening_ports", portString.c_str(), nullptr
};

mg_start(nullptr, nullptr, options);
```

