### PR TITLE
Allow setting SSL cipher list with MbedTLS

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -16805,7 +16805,8 @@ mg_sslctx_init(struct mg_context *phys_ctx, struct mg_domain_context *dom_ctx)
 		return 0;
 	}
 
-	return mbed_sslctx_init(dom_ctx->ssl_ctx, dom_ctx->config[SSL_CERTIFICATE])
+	return mbed_sslctx_init(dom_ctx->ssl_ctx, dom_ctx->config[SSL_CERTIFICATE],
+	                        dom_ctx->config[SSL_CIPHER_LIST])
 	               == 0
 	           ? 1
 	           : 0;


### PR DESCRIPTION
Currently, `ssl_cipher_list=...` is silently ignored when MbedTLS is used for TLS. This PR adds the necessary code for enabling this with MbedTLS. The supported ciphers depend on what you specified at compile-time of the library.

On my system, the following algorithms are included (no special build options used):
- TLS1-3-CHACHA20-POLY1305-SHA256 (Cipher ID: 4867, Key length: 256 bits)
- TLS1-3-AES-256-GCM-SHA384 (Cipher ID: 4866, Key length: 256 bits)
- TLS1-3-AES-128-GCM-SHA256 (Cipher ID: 4865, Key length: 128 bits)
- TLS1-3-AES-128-CCM-SHA256 (Cipher ID: 4868, Key length: 128 bits)
- TLS1-3-AES-128-CCM-8-SHA256 (Cipher ID: 4869, Key length: 128 bits)
- TLS-ECDHE-RSA-WITH-CHACHA20-POLY1305-SHA256 (Cipher ID: 52392, Key length: 256 bits)
- TLS-ECDHE-ECDSA-WITH-CHACHA20-POLY1305-SHA256 (Cipher ID: 52393, Key length: 256 bits)
- TLS-DHE-RSA-WITH-CHACHA20-POLY1305-SHA256 (Cipher ID: 52394, Key length: 256 bits)
- TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384 (Cipher ID: 49196, Key length: 256 bits)
- TLS-ECDHE-RSA-WITH-AES-256-GCM-SHA384 (Cipher ID: 49200, Key length: 256 bits)
- TLS-DHE-RSA-WITH-AES-256-GCM-SHA384 (Cipher ID: 159, Key length: 256 bits)
- TLS-ECDHE-ECDSA-WITH-AES-256-CCM (Cipher ID: 49325, Key length: 256 bits)
- TLS-DHE-RSA-WITH-AES-256-CCM (Cipher ID: 49311, Key length: 256 bits)
- TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA384 (Cipher ID: 49188, Key length: 256 bits)
- TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA384 (Cipher ID: 49192, Key length: 256 bits)
- TLS-DHE-RSA-WITH-AES-256-CBC-SHA256 (Cipher ID: 107, Key length: 256 bits)
- TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA (Cipher ID: 49162, Key length: 256 bits)
- TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA (Cipher ID: 49172, Key length: 256 bits)
- TLS-DHE-RSA-WITH-AES-256-CBC-SHA (Cipher ID: 57, Key length: 256 bits)
- TLS-ECDHE-ECDSA-WITH-AES-256-CCM-8 (Cipher ID: 49327, Key length: 256 bits)
- TLS-DHE-RSA-WITH-AES-256-CCM-8 (Cipher ID: 49315, Key length: 256 bits)
- TLS-ECDHE-ECDSA-WITH-CAMELLIA-256-GCM-SHA384 (Cipher ID: 49287, Key length: 256 bits)
- TLS-ECDHE-RSA-WITH-CAMELLIA-256-GCM-SHA384 (Cipher ID: 49291, Key length: 256 bits)
- TLS-DHE-RSA-WITH-CAMELLIA-256-GCM-SHA384 (Cipher ID: 49277, Key length: 256 bits)
- TLS-ECDHE-ECDSA-WITH-CAMELLIA-256-CBC-SHA384 (Cipher ID: 49267, Key length: 256 bits)
- TLS-ECDHE-RSA-WITH-CAMELLIA-256-CBC-SHA384 (Cipher ID: 49271, Key length: 256 bits)
- TLS-DHE-RSA-WITH-CAMELLIA-256-CBC-SHA256 (Cipher ID: 196, Key length: 256 bits)
- TLS-DHE-RSA-WITH-CAMELLIA-256-CBC-SHA (Cipher ID: 136, Key length: 256 bits)
- TLS-ECDHE-ECDSA-WITH-ARIA-256-GCM-SHA384 (Cipher ID: 49245, Key length: 256 bits)
- TLS-ECDHE-RSA-WITH-ARIA-256-GCM-SHA384 (Cipher ID: 49249, Key length: 256 bits)
- TLS-DHE-RSA-WITH-ARIA-256-GCM-SHA384 (Cipher ID: 49235, Key length: 256 bits)
- TLS-ECDHE-ECDSA-WITH-ARIA-256-CBC-SHA384 (Cipher ID: 49225, Key length: 256 bits)
- TLS-ECDHE-RSA-WITH-ARIA-256-CBC-SHA384 (Cipher ID: 49229, Key length: 256 bits)
- TLS-DHE-RSA-WITH-ARIA-256-CBC-SHA384 (Cipher ID: 49221, Key length: 256 bits)
- TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 (Cipher ID: 49195, Key length: 128 bits)
- TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256 (Cipher ID: 49199, Key length: 128 bits)
- TLS-DHE-RSA-WITH-AES-128-GCM-SHA256 (Cipher ID: 158, Key length: 128 bits)
- TLS-ECDHE-ECDSA-WITH-AES-128-CCM (Cipher ID: 49324, Key length: 128 bits)
- TLS-DHE-RSA-WITH-AES-128-CCM (Cipher ID: 49310, Key length: 128 bits)
- TLS-ECDHE-ECDSA-WITH-AES-128-CBC-SHA256 (Cipher ID: 49187, Key length: 128 bits)
- TLS-ECDHE-RSA-WITH-AES-128-CBC-SHA256 (Cipher ID: 49191, Key length: 128 bits)
- TLS-DHE-RSA-WITH-AES-128-CBC-SHA256 (Cipher ID: 103, Key length: 128 bits)
- TLS-ECDHE-ECDSA-WITH-AES-128-CBC-SHA (Cipher ID: 49161, Key length: 128 bits)
- TLS-ECDHE-RSA-WITH-AES-128-CBC-SHA (Cipher ID: 49171, Key length: 128 bits)
- TLS-DHE-RSA-WITH-AES-128-CBC-SHA (Cipher ID: 51, Key length: 128 bits)
- TLS-ECDHE-ECDSA-WITH-AES-128-CCM-8 (Cipher ID: 49326, Key length: 128 bits)
- TLS-DHE-RSA-WITH-AES-128-CCM-8 (Cipher ID: 49314, Key length: 128 bits)
- TLS-ECDHE-ECDSA-WITH-CAMELLIA-128-GCM-SHA256 (Cipher ID: 49286, Key length: 128 bits)
- TLS-ECDHE-RSA-WITH-CAMELLIA-128-GCM-SHA256 (Cipher ID: 49290, Key length: 128 bits)
- TLS-DHE-RSA-WITH-CAMELLIA-128-GCM-SHA256 (Cipher ID: 49276, Key length: 128 bits)
- TLS-ECDHE-ECDSA-WITH-CAMELLIA-128-CBC-SHA256 (Cipher ID: 49266, Key length: 128 bits)
- TLS-ECDHE-RSA-WITH-CAMELLIA-128-CBC-SHA256 (Cipher ID: 49270, Key length: 128 bits)
- TLS-DHE-RSA-WITH-CAMELLIA-128-CBC-SHA256 (Cipher ID: 190, Key length: 128 bits)
- TLS-DHE-RSA-WITH-CAMELLIA-128-CBC-SHA (Cipher ID: 69, Key length: 128 bits)
- TLS-ECDHE-ECDSA-WITH-ARIA-128-GCM-SHA256 (Cipher ID: 49244, Key length: 128 bits)
- TLS-ECDHE-RSA-WITH-ARIA-128-GCM-SHA256 (Cipher ID: 49248, Key length: 128 bits)
- TLS-DHE-RSA-WITH-ARIA-128-GCM-SHA256 (Cipher ID: 49234, Key length: 128 bits)
- TLS-ECDHE-ECDSA-WITH-ARIA-128-CBC-SHA256 (Cipher ID: 49224, Key length: 128 bits)
- TLS-ECDHE-RSA-WITH-ARIA-128-CBC-SHA256 (Cipher ID: 49228, Key length: 128 bits)
- TLS-DHE-RSA-WITH-ARIA-128-CBC-SHA256 (Cipher ID: 49220, Key length: 128 bits)
- TLS-ECDHE-PSK-WITH-CHACHA20-POLY1305-SHA256 (Cipher ID: 52396, Key length: 256 bits)
- TLS-DHE-PSK-WITH-CHACHA20-POLY1305-SHA256 (Cipher ID: 52397, Key length: 256 bits)
- TLS-DHE-PSK-WITH-AES-256-GCM-SHA384 (Cipher ID: 171, Key length: 256 bits)
- TLS-DHE-PSK-WITH-AES-256-CCM (Cipher ID: 49319, Key length: 256 bits)
- TLS-ECDHE-PSK-WITH-AES-256-CBC-SHA384 (Cipher ID: 49208, Key length: 256 bits)
- TLS-DHE-PSK-WITH-AES-256-CBC-SHA384 (Cipher ID: 179, Key length: 256 bits)
- TLS-ECDHE-PSK-WITH-AES-256-CBC-SHA (Cipher ID: 49206, Key length: 256 bits)
- TLS-DHE-PSK-WITH-AES-256-CBC-SHA (Cipher ID: 145, Key length: 256 bits)
- TLS-DHE-PSK-WITH-CAMELLIA-256-GCM-SHA384 (Cipher ID: 49297, Key length: 256 bits)
- TLS-ECDHE-PSK-WITH-CAMELLIA-256-CBC-SHA384 (Cipher ID: 49307, Key length: 256 bits)
- TLS-DHE-PSK-WITH-CAMELLIA-256-CBC-SHA384 (Cipher ID: 49303, Key length: 256 bits)
- TLS-DHE-PSK-WITH-AES-256-CCM-8 (Cipher ID: 49323, Key length: 256 bits)
- TLS-DHE-PSK-WITH-ARIA-256-GCM-SHA384 (Cipher ID: 49261, Key length: 256 bits)
- TLS-ECDHE-PSK-WITH-ARIA-256-CBC-SHA384 (Cipher ID: 49265, Key length: 256 bits)
- TLS-DHE-PSK-WITH-ARIA-256-CBC-SHA384 (Cipher ID: 49255, Key length: 256 bits)
- TLS-DHE-PSK-WITH-AES-128-GCM-SHA256 (Cipher ID: 170, Key length: 128 bits)
- TLS-DHE-PSK-WITH-AES-128-CCM (Cipher ID: 49318, Key length: 128 bits)
- TLS-ECDHE-PSK-WITH-AES-128-CBC-SHA256 (Cipher ID: 49207, Key length: 128 bits)
- TLS-DHE-PSK-WITH-AES-128-CBC-SHA256 (Cipher ID: 178, Key length: 128 bits)
- TLS-ECDHE-PSK-WITH-AES-128-CBC-SHA (Cipher ID: 49205, Key length: 128 bits)
- TLS-DHE-PSK-WITH-AES-128-CBC-SHA (Cipher ID: 144, Key length: 128 bits)
- TLS-DHE-PSK-WITH-CAMELLIA-128-GCM-SHA256 (Cipher ID: 49296, Key length: 128 bits)
- TLS-DHE-PSK-WITH-CAMELLIA-128-CBC-SHA256 (Cipher ID: 49302, Key length: 128 bits)
- TLS-ECDHE-PSK-WITH-CAMELLIA-128-CBC-SHA256 (Cipher ID: 49306, Key length: 128 bits)
- TLS-DHE-PSK-WITH-AES-128-CCM-8 (Cipher ID: 49322, Key length: 128 bits)
- TLS-DHE-PSK-WITH-ARIA-128-GCM-SHA256 (Cipher ID: 49260, Key length: 128 bits)
- TLS-ECDHE-PSK-WITH-ARIA-128-CBC-SHA256 (Cipher ID: 49264, Key length: 128 bits)
- TLS-DHE-PSK-WITH-ARIA-128-CBC-SHA256 (Cipher ID: 49254, Key length: 128 bits)
- TLS-RSA-WITH-AES-256-GCM-SHA384 (Cipher ID: 157, Key length: 256 bits)
- TLS-RSA-WITH-AES-256-CCM (Cipher ID: 49309, Key length: 256 bits)
- TLS-RSA-WITH-AES-256-CBC-SHA256 (Cipher ID: 61, Key length: 256 bits)
- TLS-RSA-WITH-AES-256-CBC-SHA (Cipher ID: 53, Key length: 256 bits)
- TLS-ECDH-RSA-WITH-AES-256-GCM-SHA384 (Cipher ID: 49202, Key length: 256 bits)
- TLS-ECDH-RSA-WITH-AES-256-CBC-SHA384 (Cipher ID: 49194, Key length: 256 bits)
- TLS-ECDH-RSA-WITH-AES-256-CBC-SHA (Cipher ID: 49167, Key length: 256 bits)
- TLS-ECDH-ECDSA-WITH-AES-256-GCM-SHA384 (Cipher ID: 49198, Key length: 256 bits)
- TLS-ECDH-ECDSA-WITH-AES-256-CBC-SHA384 (Cipher ID: 49190, Key length: 256 bits)
- TLS-ECDH-ECDSA-WITH-AES-256-CBC-SHA (Cipher ID: 49157, Key length: 256 bits)
- TLS-RSA-WITH-AES-256-CCM-8 (Cipher ID: 49313, Key length: 256 bits)
- TLS-RSA-WITH-CAMELLIA-256-GCM-SHA384 (Cipher ID: 49275, Key length: 256 bits)
- TLS-RSA-WITH-CAMELLIA-256-CBC-SHA256 (Cipher ID: 192, Key length: 256 bits)
- TLS-RSA-WITH-CAMELLIA-256-CBC-SHA (Cipher ID: 132, Key length: 256 bits)
- TLS-ECDH-RSA-WITH-CAMELLIA-256-GCM-SHA384 (Cipher ID: 49293, Key length: 256 bits)
- TLS-ECDH-RSA-WITH-CAMELLIA-256-CBC-SHA384 (Cipher ID: 49273, Key length: 256 bits)
- TLS-ECDH-ECDSA-WITH-CAMELLIA-256-GCM-SHA384 (Cipher ID: 49289, Key length: 256 bits)
- TLS-ECDH-ECDSA-WITH-CAMELLIA-256-CBC-SHA384 (Cipher ID: 49269, Key length: 256 bits)
- TLS-ECDH-ECDSA-WITH-ARIA-256-GCM-SHA384 (Cipher ID: 49247, Key length: 256 bits)
- TLS-ECDH-RSA-WITH-ARIA-256-GCM-SHA384 (Cipher ID: 49251, Key length: 256 bits)
- TLS-RSA-WITH-ARIA-256-GCM-SHA384 (Cipher ID: 49233, Key length: 256 bits)
- TLS-ECDH-ECDSA-WITH-ARIA-256-CBC-SHA384 (Cipher ID: 49227, Key length: 256 bits)
- TLS-ECDH-RSA-WITH-ARIA-256-CBC-SHA384 (Cipher ID: 49231, Key length: 256 bits)
- TLS-RSA-WITH-ARIA-256-CBC-SHA384 (Cipher ID: 49213, Key length: 256 bits)
- TLS-RSA-WITH-AES-128-GCM-SHA256 (Cipher ID: 156, Key length: 128 bits)
- TLS-RSA-WITH-AES-128-CCM (Cipher ID: 49308, Key length: 128 bits)
- TLS-RSA-WITH-AES-128-CBC-SHA256 (Cipher ID: 60, Key length: 128 bits)
- TLS-RSA-WITH-AES-128-CBC-SHA (Cipher ID: 47, Key length: 128 bits)
- TLS-ECDH-RSA-WITH-AES-128-GCM-SHA256 (Cipher ID: 49201, Key length: 128 bits)
- TLS-ECDH-RSA-WITH-AES-128-CBC-SHA256 (Cipher ID: 49193, Key length: 128 bits)
- TLS-ECDH-RSA-WITH-AES-128-CBC-SHA (Cipher ID: 49166, Key length: 128 bits)
- TLS-ECDH-ECDSA-WITH-AES-128-GCM-SHA256 (Cipher ID: 49197, Key length: 128 bits)
- TLS-ECDH-ECDSA-WITH-AES-128-CBC-SHA256 (Cipher ID: 49189, Key length: 128 bits)
- TLS-ECDH-ECDSA-WITH-AES-128-CBC-SHA (Cipher ID: 49156, Key length: 128 bits)
- TLS-RSA-WITH-AES-128-CCM-8 (Cipher ID: 49312, Key length: 128 bits)
- TLS-RSA-WITH-CAMELLIA-128-GCM-SHA256 (Cipher ID: 49274, Key length: 128 bits)
- TLS-RSA-WITH-CAMELLIA-128-CBC-SHA256 (Cipher ID: 186, Key length: 128 bits)
- TLS-RSA-WITH-CAMELLIA-128-CBC-SHA (Cipher ID: 65, Key length: 128 bits)
- TLS-ECDH-RSA-WITH-CAMELLIA-128-GCM-SHA256 (Cipher ID: 49292, Key length: 128 bits)
- TLS-ECDH-RSA-WITH-CAMELLIA-128-CBC-SHA256 (Cipher ID: 49272, Key length: 128 bits)
- TLS-ECDH-ECDSA-WITH-CAMELLIA-128-GCM-SHA256 (Cipher ID: 49288, Key length: 128 bits)
- TLS-ECDH-ECDSA-WITH-CAMELLIA-128-CBC-SHA256 (Cipher ID: 49268, Key length: 128 bits)
- TLS-ECDH-ECDSA-WITH-ARIA-128-GCM-SHA256 (Cipher ID: 49246, Key length: 128 bits)
- TLS-ECDH-RSA-WITH-ARIA-128-GCM-SHA256 (Cipher ID: 49250, Key length: 128 bits)
- TLS-RSA-WITH-ARIA-128-GCM-SHA256 (Cipher ID: 49232, Key length: 128 bits)
- TLS-ECDH-ECDSA-WITH-ARIA-128-CBC-SHA256 (Cipher ID: 49226, Key length: 128 bits)
- TLS-ECDH-RSA-WITH-ARIA-128-CBC-SHA256 (Cipher ID: 49230, Key length: 128 bits)
- TLS-RSA-WITH-ARIA-128-CBC-SHA256 (Cipher ID: 49212, Key length: 128 bits)
- TLS-RSA-PSK-WITH-CHACHA20-POLY1305-SHA256 (Cipher ID: 52398, Key length: 256 bits)
- TLS-RSA-PSK-WITH-AES-256-GCM-SHA384 (Cipher ID: 173, Key length: 256 bits)
- TLS-RSA-PSK-WITH-AES-256-CBC-SHA384 (Cipher ID: 183, Key length: 256 bits)
- TLS-RSA-PSK-WITH-AES-256-CBC-SHA (Cipher ID: 149, Key length: 256 bits)
- TLS-RSA-PSK-WITH-CAMELLIA-256-GCM-SHA384 (Cipher ID: 49299, Key length: 256 bits)
- TLS-RSA-PSK-WITH-CAMELLIA-256-CBC-SHA384 (Cipher ID: 49305, Key length: 256 bits)
- TLS-RSA-PSK-WITH-ARIA-256-GCM-SHA384 (Cipher ID: 49263, Key length: 256 bits)
- TLS-RSA-PSK-WITH-ARIA-256-CBC-SHA384 (Cipher ID: 49257, Key length: 256 bits)
- TLS-RSA-PSK-WITH-AES-128-GCM-SHA256 (Cipher ID: 172, Key length: 128 bits)
- TLS-RSA-PSK-WITH-AES-128-CBC-SHA256 (Cipher ID: 182, Key length: 128 bits)
- TLS-RSA-PSK-WITH-AES-128-CBC-SHA (Cipher ID: 148, Key length: 128 bits)
- TLS-RSA-PSK-WITH-CAMELLIA-128-GCM-SHA256 (Cipher ID: 49298, Key length: 128 bits)
- TLS-RSA-PSK-WITH-CAMELLIA-128-CBC-SHA256 (Cipher ID: 49304, Key length: 128 bits)
- TLS-RSA-PSK-WITH-ARIA-128-GCM-SHA256 (Cipher ID: 49262, Key length: 128 bits)
- TLS-RSA-PSK-WITH-ARIA-128-CBC-SHA256 (Cipher ID: 49256, Key length: 128 bits)
- TLS-PSK-WITH-CHACHA20-POLY1305-SHA256 (Cipher ID: 52395, Key length: 256 bits)
- TLS-PSK-WITH-AES-256-GCM-SHA384 (Cipher ID: 169, Key length: 256 bits)
- TLS-PSK-WITH-AES-256-CCM (Cipher ID: 49317, Key length: 256 bits)
- TLS-PSK-WITH-AES-256-CBC-SHA384 (Cipher ID: 175, Key length: 256 bits)
- TLS-PSK-WITH-AES-256-CBC-SHA (Cipher ID: 141, Key length: 256 bits)
- TLS-PSK-WITH-CAMELLIA-256-GCM-SHA384 (Cipher ID: 49295, Key length: 256 bits)
- TLS-PSK-WITH-CAMELLIA-256-CBC-SHA384 (Cipher ID: 49301, Key length: 256 bits)
- TLS-PSK-WITH-AES-256-CCM-8 (Cipher ID: 49321, Key length: 256 bits)
- TLS-PSK-WITH-ARIA-256-GCM-SHA384 (Cipher ID: 49259, Key length: 256 bits)
- TLS-PSK-WITH-ARIA-256-CBC-SHA384 (Cipher ID: 49253, Key length: 256 bits)
- TLS-PSK-WITH-AES-128-GCM-SHA256 (Cipher ID: 168, Key length: 128 bits)
- TLS-PSK-WITH-AES-128-CCM (Cipher ID: 49316, Key length: 128 bits)
- TLS-PSK-WITH-AES-128-CBC-SHA256 (Cipher ID: 174, Key length: 128 bits)
- TLS-PSK-WITH-AES-128-CBC-SHA (Cipher ID: 140, Key length: 128 bits)
- TLS-PSK-WITH-CAMELLIA-128-GCM-SHA256 (Cipher ID: 49294, Key length: 128 bits)
- TLS-PSK-WITH-CAMELLIA-128-CBC-SHA256 (Cipher ID: 49300, Key length: 128 bits)
- TLS-PSK-WITH-AES-128-CCM-8 (Cipher ID: 49320, Key length: 128 bits)
- TLS-PSK-WITH-ARIA-128-GCM-SHA256 (Cipher ID: 49258, Key length: 128 bits)
- TLS-PSK-WITH-ARIA-128-CBC-SHA256 (Cipher ID: 49252, Key length: 128 bits)