### PR TITLE
add server address to reqinfo

### DIFF
--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -164,6 +164,7 @@ struct mg_request_info {
 	const char *remote_user;    /* Authenticated user, or NULL if no auth
 	                               used */
 	char remote_addr[48];       /* Client's IP address as a string. */
+	char server_addr[48];       /* Server's IP address as a string. */
 
 	long long content_length; /* Length (in bytes) of the request body,
 	                             can be -1 if no length was given. */

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -20364,6 +20364,10 @@ worker_thread_run(struct mg_connection *conn)
 		sockaddr_to_string(conn->request_info.remote_addr,
 		                   sizeof(conn->request_info.remote_addr),
 		                   &conn->client.rsa);
+ 
+		sockaddr_to_string(conn->request_info.server_addr,
+		                   sizeof(conn->request_info.server_addr),
+		                   &conn->client.lsa);
 
 		DEBUG_TRACE("Incoming %sconnection from %s",
 		            (conn->client.is_ssl ? "SSL " : ""),


### PR DESCRIPTION
Add server address to reqinfo to allow handlers to determine where request was addressed to.