### PR TITLE
Fix missing lua_websock_data declaration w/o USE_WEBSOCKET

### DIFF
--- a/src/mod_lua.inl
+++ b/src/mod_lua.inl
@@ -1977,6 +1977,9 @@ struct lua_websock_data {
 	struct mg_connection *conn[MAX_WORKER_THREADS];
 	pthread_mutex_t ws_mutex;
 };
+#else
+/* used in parameter list of prepare_lua_environment() */
+struct lua_websock_data;
 #endif
 
 
@@ -2886,11 +2889,13 @@ prepare_lua_environment(struct mg_context *ctx,
 #endif
 
 	/* Store context in the registry */
+#if defined(USE_WEBSOCKET)
 	if (ctx != NULL) {
 		lua_pushlightuserdata(L, (void *)&lua_regkey_ctx);
 		lua_pushlightuserdata(L, (void *)ctx);
 		lua_settable(L, LUA_REGISTRYINDEX);
 	}
+#endif /* USE_WEBSOCKET */
 	if (ws_conn_list != NULL) {
 		lua_pushlightuserdata(L, (void *)&lua_regkey_connlist);
 		lua_pushlightuserdata(L, (void *)ws_conn_list);


### PR DESCRIPTION
This was originally observed in pi-hole/FTL, which integrates civetweb with minor changes. The maintainers rightly observed that this fix should be applied upstream.

[Excerpt from pull request](https://github.com/pi-hole/FTL/pull/2762/changes/09a361a)
[Discussion](https://github.com/pi-hole/FTL/pull/2762#issuecomment-3957206784)
___

If civetweb.c is compiled with USE_WEBSOCKET undefined, a compiler warning is raised:

```
In file included from [...]/pihole-ftl-6.5/src/webserver/civetweb/civetweb.c:13436: [...]/pihole-ftl-6.5/src/webserver/civetweb/mod_lua.inl:2852:32: warning: ‘struct lua_websock_data’ declared inside parameter list will not be visible outside of this definition or declaration
 2852 |                         struct lua_websock_data *ws_conn_list,
      |                                ^~~~~~~~~~~~~~~~
```

The reason for this warning is a missing declaration of struct lua_websock_data, which is omitted due to USE_WEBSOCKET being undefined.

For safety reasons, the code related to this parameter in function prepare_lua_environment() should also be omitted, if USE_WEBSOCKET is undefined.

Fix missing declaration of lua_websock_data and disable code related to unused function parameter in prepare_lua_environment().