### PR TITLE
Fixed old variable names

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -19201,15 +19201,15 @@ get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 		conn->accept_gzip = 1;
 	}
 #endif
-   h_chunk = get_header(conn->request_info.http_headers,
+   	h_chunk = get_header(conn->request_info.http_headers,
 	                      conn->request_info.num_headers,
 	                      "Transfer-Encoding");
-   h_len = get_header(conn->request_info.http_headers,
+   	h_len = get_header(conn->request_info.http_headers,
 	                            conn->request_info.num_headers,
 	                            "Content-Length");
-	if (h_chunk != NULL)
-	    && mg_strcasecmp(cl, "identity")) {
-		if ((0!=mg_strcasecmp(cl, "chunked")) || (h_len!=NULL)) {
+	if ((h_chunk != NULL)
+	    && mg_strcasecmp(h_chunk, "identity")) {
+		if ((0!=mg_strcasecmp(h_chunk, "chunked")) || (h_len!=NULL)) {
 			mg_snprintf(conn,
 			            NULL, /* No truncation check for ebuf */
 			            ebuf,
@@ -19224,8 +19224,8 @@ get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 	} else if (h_len != NULL) {
 		/* Request has content length set */
 		char *endptr = NULL;
-		conn->content_len = strtoll(cl, &endptr, 10);
-		if ((endptr == cl) || (conn->content_len < 0)) {
+		conn->content_len = strtoll(h_len, &endptr, 10);
+		if ((endptr == h_len) || (conn->content_len < 0)) {
 			mg_snprintf(conn,
 			            NULL, /* No truncation check for ebuf */
 			            ebuf,


### PR DESCRIPTION
Related to issue #1386
This PR fixes the build errors caused by missing changes in the latest commits.

```
civetweb.c:19212:39: error: ‘cl’ undeclared (first use in this function)
19212 |                 if ((0!=mg_strcasecmp(cl, "chunked")) || (h_len!=NULL)) {
civetweb.c:19211:13: error: taking the address of a label is non-standard [-Wpedantic]
19211 |             && mg_strcasecmp(cl, "identity")) {
      |             ^~
civetweb.c:19211:13: warning: statement with no effect [-Wunused-value]
19211 |             && mg_strcasecmp(cl, "identity")) {
      |             ^~~~~~~~~~~~~~~~
civetweb.c:19211:29: error: expected ‘;’ before ‘(’ token
19211 |             && mg_strcasecmp(cl, "identity")) {
```