### PR TITLE
Fix potentially empty SSL error output

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -16940,6 +16940,7 @@ sslize(struct mg_connection *conn,
 	int short_trust;
 	unsigned timeout = 1024;
 	unsigned i;
+	char* error_str;
 
 	if (!conn) {
 		return 0;
@@ -17048,8 +17049,12 @@ sslize(struct mg_connection *conn,
 				break;
 
 			} else {
-				/* This is an SSL specific error, e.g. SSL_ERROR_SSL */
-				mg_cry_internal(conn, "sslize error: %s", ssl_error());
+				error_str = ssl_error();
+				if(error_str && error_str[0])
+				{
+					/* This is an SSL specific error, e.g. SSL_ERROR_SSL */
+					mg_cry_internal(conn, "sslize error: %s", error_str);
+				}
 				break;
 			}
 


### PR DESCRIPTION
Hello! Thank you for the project.

This change prevents empty `"sslize error: "` messages when OpenSSL 3+ is used in combination with [SSL_OP_IGNORE_UNEXPECTED_EOF ](https://docs.openssl.org/3.2/man3/SSL_CTX_set_options/) being set on the SSL context.

Setting this option causes the error SSL_ERROR_ZERO_RETURN in the unexpected EOF cases and ssl_error() returns an empty string. See https://docs.openssl.org/3.2/man3/SSL_get_error/#notes.