### PR TITLE
Only include deprecated header when really necessary

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -1797,7 +1797,10 @@ typedef struct SSL_CTX SSL_CTX;
 #include <openssl/conf.h>
 #include <openssl/crypto.h>
 #include <openssl/dh.h>
-#include <openssl/engine.h>
+
+#if defined(OPENSSL_API_1_0)
+#include <openssl/engine.h> // deprecated later on
+#endif
 #include <openssl/err.h>
 #include <openssl/opensslv.h>
 #include <openssl/pem.h>


### PR DESCRIPTION
deprecated openssl ENGINE API is only used `#if !defined(OPENSSL_API_1_1) && !defined(OPENSSL_API_3_0)`

And it will be fully removed later on, so avoid compilation errors in fedora etc.

see https://openssl-library.org/post/2025-12-18-remove-engines/