### PR TITLE
Add passive mbedtls threading safety check

### DIFF
--- a/src/mod_mbedtls.inl
+++ b/src/mod_mbedtls.inl
@@ -19,9 +19,19 @@
 #include "mbedtls/pk.h"
 #include "mbedtls/platform.h"
 #include "mbedtls/ssl.h"
+#include "mbedtls/threading.h"
 #include "mbedtls/x509.h"
 #include "mbedtls/x509_crt.h"
 #include <string.h>
+
+/* libmbedtls must be built with MBEDTLS_THREADING_C: without it the PSA crypto
+ * subsystem's global DRBG/entropy state is unprotected, and concurrent TLS
+ * handshakes across civetweb worker threads will race inside
+ * mbedtls_entropy_func and SIGSEGV in mbedtls_md_free. See
+ * github.com/pi-hole/FTL/issues/2871. */
+#if !defined(MBEDTLS_THREADING_C)
+#error "libmbedtls must be built with MBEDTLS_THREADING_C"
+#endif
 
 typedef mbedtls_ssl_context SSL;
 

--- a/src/mod_mbedtls.inl
+++ b/src/mod_mbedtls.inl
@@ -28,7 +28,7 @@
  * subsystem's global DRBG/entropy state is unprotected, and concurrent TLS
  * handshakes across civetweb worker threads will race inside
  * mbedtls_entropy_func and SIGSEGV in mbedtls_md_free. See
- * github.com/pi-hole/FTL/issues/2871. */
+ * https://github.com/pi-hole/FTL/issues/2871. */
 #if !defined(MBEDTLS_THREADING_C)
 #error "libmbedtls must be built with MBEDTLS_THREADING_C"
 #endif


### PR DESCRIPTION
In 4.0 PSA is the mandatory crypto backend. Every TLS handshake's `ssl_write_server_hello` pulls randomness from a single global PSA DRBG that, without `MBEDTLS_THREADING_C`, has no mutex.

The up to 50 worker threads in our CivetWeb-based webserver caused concurrent handshakes and raced inside `mbedtls_entropy_func`'s accumulator reset (`mbedtls_md_free` followed by `mbedtls_md_init`+`mbedtls_md_setup`), eventually freeing some already-freed SHA accumulator buffer resulting a a double-free crash.

The solution is easy: Ensure `mbedtls` has been build with threading support. This commit merely adds a safety net clearly highlighting this as an error to prevent future developers from wasting weeks until nailing this down.