### PR TITLE
Fix compilation error in get_request(): broken if condition and undeclared 'cl'

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -19207,9 +19207,9 @@ get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
    h_len = get_header(conn->request_info.http_headers,
 	                            conn->request_info.num_headers,
 	                            "Content-Length");
-	if (h_chunk != NULL)
-	    && mg_strcasecmp(cl, "identity")) {
-		if ((0!=mg_strcasecmp(cl, "chunked")) || (h_len!=NULL)) {
+	if ((h_chunk != NULL)
+	    && mg_strcasecmp(h_chunk, "identity")) {
+		if ((0!=mg_strcasecmp(h_chunk, "chunked")) || (h_len!=NULL)) {
 			mg_snprintf(conn,
 			            NULL, /* No truncation check for ebuf */
 			            ebuf,
@@ -19224,8 +19224,8 @@ get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 	} else if (h_len != NULL) {
 		/* Request has content length set */
 		char *endptr = NULL;
-		conn->content_len = strtoll(cl, &endptr, 10);
-		if ((endptr == cl) || (conn->content_len < 0)) {
+		conn->content_len = strtoll(h_len, &endptr, 10);
+		if ((endptr == h_len) || (conn->content_len < 0)) {
 			mg_snprintf(conn,
 			            NULL, /* No truncation check for ebuf */
 			            ebuf,


### PR DESCRIPTION
## Problem

Commit 588860e (CVE-2025-55763) introduced a syntax error in `get_request()` that breaks compilation on both GCC and clang, causing the entire CI to fail.

**Two bugs in the same block:**

**1. Malformed `if` condition** — the opening parenthesis is missing:

```c
// broken
if (h_chunk != NULL)
    && mg_strcasecmp(cl, "identity")) {
```

The compiler sees `if (h_chunk != NULL)` as a complete statement with an empty body, then `&& mg_strcasecmp(...)` as an invalid standalone expression. GCC reports *"taking the address of a label is non-standard"* and *"expected ';' before '(' token"*; clang reports *"expression cannot be followed by a postfix '(' operator"*.

**2. Undeclared variable `cl`** — `cl` is not in scope at this point. The intended variable is `h_chunk` (the Transfer-Encoding header value) in the chunked-check block, and `h_len` (the Content-Length header value) in the content-length `else` branch.

## Fix

```c
// Transfer-Encoding block
if ((h_chunk != NULL)
    && mg_strcasecmp(h_chunk, "identity")) {
    if ((0 != mg_strcasecmp(h_chunk, "chunked")) || (h_len != NULL)) {

// Content-Length block
conn->content_len = strtoll(h_len, &endptr, 10);
if ((endptr == h_len) || (conn->content_len < 0)) {
```

## Test plan

- [ ] Confirm the build passes on Linux (GCC) and macOS (Clang).
- [ ] Run the existing test suite to verify chunked + Content-Length rejection still works.