### PR TITLE
Set build mode to manual for CodeQl workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,6 +65,7 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
         queries: security-and-quality
+        build-mode: manual
 
 
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).


### PR DESCRIPTION
Fixes the CI CodeQl warning about undefined build mode. As we build civetweb manually for the analysis, I set it to 'manual'

<img width="2476" height="162" alt="2026-06-03_08-52" src="https://github.com/user-attachments/assets/eb18af10-298e-4663-a5dc-6bf0deef2c4d" />
