### PR TITLE
mbedTLS: wait on the socket instead of busy-spinning on WANT_READ/WRITE

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -6166,6 +6166,10 @@ push_inner(struct mg_context *ctx,
 	/* Try to read until it succeeds, fails, times out, or the server
 	 * shuts down. */
 	for (;;) {
+		/* Which socket event to wait for before retrying a write that made
+		 * no progress. Default to write-readiness; a non-blocking TLS write
+		 * can instead need read-readiness (see the mbedTLS branch below). */
+		int want_events = POLLOUT;
 
 #if defined(USE_MBEDTLS)
 		if (ssl != NULL) {
@@ -6174,6 +6178,14 @@ push_inner(struct mg_context *ctx,
 				if ((n == MBEDTLS_ERR_SSL_WANT_READ)
 				    || (n == MBEDTLS_ERR_SSL_WANT_WRITE)
 				    || n == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS) {
+					/* mbedTLS may need to read (e.g. during a
+					 * renegotiation) before it can write. Wait for the
+					 * operation it actually asked for: polling for write-
+					 * readiness while it wants to read busy-spins at 100%
+					 * CPU because the socket is almost always writable. */
+					if (n == MBEDTLS_ERR_SSL_WANT_READ) {
+						want_events = POLLIN;
+					}
 					n = 0;
 				} else {
 					fprintf(stderr, "SSL write failed, error %d\n", n);
@@ -6275,7 +6287,7 @@ push_inner(struct mg_context *ctx,
 			unsigned int num_sock = 1;
 
 			pfd[0].fd = sock;
-			pfd[0].events = POLLOUT;
+			pfd[0].events = (short)want_events;
 
 			if (ctx->context_type == CONTEXT_SERVER) {
 				pfd[num_sock].fd = ctx->thread_shutdown_notification_socket;
@@ -6435,6 +6447,30 @@ pull_inner(FILE *fp,
 				if ((nread == MBEDTLS_ERR_SSL_WANT_READ)
 				    || (nread == MBEDTLS_ERR_SSL_WANT_WRITE)
 				    || nread == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS) {
+					/* mbedTLS consumed data from the socket (e.g. a non-
+					 * application TLS record) or holds buffered data that
+					 * does not yield application bytes yet, so the socket can
+					 * stay poll-readable while no progress is visible here.
+					 * Wait for the socket to become ready for the operation
+					 * mbedTLS asked for (read vs. write), bounded by the
+					 * request timeout, instead of returning immediately and
+					 * letting the request loop busy-spin at 100% CPU. */
+					num_sock = 1;
+					pfd[0].fd = conn->client.sock;
+					pfd[0].events =
+					    (nread == MBEDTLS_ERR_SSL_WANT_WRITE) ? POLLOUT : POLLIN;
+
+					if (conn->phys_ctx->context_type == CONTEXT_SERVER) {
+						pfd[num_sock].fd =
+						    conn->phys_ctx->thread_shutdown_notification_socket;
+						pfd[num_sock].events = POLLIN;
+						num_sock++;
+					}
+
+					mg_poll(pfd,
+					        num_sock,
+					        (int)(timeout * 1000.0),
+					        &(conn->phys_ctx->stop_flag));
 					nread = 0;
 				} else {
 					fprintf(stderr, "SSL read failed, error %d\n", nread);

--- a/src/mod_mbedtls.inl
+++ b/src/mod_mbedtls.inl
@@ -55,7 +55,8 @@ static void mbed_debug(void *context,
                        const char *file,
                        int line,
                        const char *str);
-static int mbed_ssl_handshake(mbedtls_ssl_context *ssl);
+static int mbed_ssl_handshake(mbedtls_ssl_context *ssl,
+                              mbedtls_net_context *client_fd);
 
 
 int
@@ -217,7 +218,10 @@ mbed_ssl_accept(mbedtls_ssl_context **ssl,
 	mbedtls_ssl_init(*ssl);
 	mbedtls_ssl_setup(*ssl, &ssl_ctx->conf);
 	mbedtls_ssl_set_bio(*ssl, sock, mbedtls_net_send, mbedtls_net_recv, NULL);
-	rc = mbed_ssl_handshake(*ssl);
+	/* The bio context is the accepted (non-blocking) socket fd. mbedTLS
+	 * treats it as an mbedtls_net_context, whose only member is that fd, so
+	 * we can poll it directly while driving the handshake. */
+	rc = mbed_ssl_handshake(*ssl, (mbedtls_net_context *)sock);
 	if (rc != 0) {
 		DEBUG_TRACE("TLS handshake failed (%i)", rc);
 		mbedtls_ssl_free(*ssl);
@@ -248,14 +252,38 @@ mbed_ssl_close(mbedtls_ssl_context *ssl)
 
 
 static int
-mbed_ssl_handshake(mbedtls_ssl_context *ssl)
+mbed_ssl_handshake(mbedtls_ssl_context *ssl, mbedtls_net_context *client_fd)
 {
 	int rc;
 	while ((rc = mbedtls_ssl_handshake(ssl)) != 0) {
-		if (rc != MBEDTLS_ERR_SSL_WANT_READ && rc != MBEDTLS_ERR_SSL_WANT_WRITE
-		    && rc != MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS) {
+		uint32_t rw;
+
+		if (rc == MBEDTLS_ERR_SSL_WANT_READ) {
+			rw = MBEDTLS_NET_POLL_READ;
+		} else if (rc == MBEDTLS_ERR_SSL_WANT_WRITE) {
+			rw = MBEDTLS_NET_POLL_WRITE;
+		} else if (rc == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS) {
+			/* The crypto operation was offloaded to an async provider:
+			 * there is no socket event to wait for, so yield briefly and
+			 * retry instead of spinning the worker thread. */
+			mg_sleep(1);
+			continue;
+		} else {
+			/* Genuine handshake error */
 			break;
 		}
+
+		/* Accepted sockets are non-blocking. Block until the socket is
+		 * ready for the operation mbedTLS is waiting for, instead of
+		 * spinning a worker thread at 100% CPU. The finite timeout keeps
+		 * the loop responsive (e.g. to the socket being closed on server
+		 * shutdown). */
+		rc = mbedtls_net_poll(client_fd, rw, SOCKET_TIMEOUT_QUANTUM);
+		if (rc < 0) {
+			/* Poll error: abort the handshake */
+			break;
+		}
+		/* rc >= 0: socket became ready or the poll timed out; retry. */
 	}
 
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000


### PR DESCRIPTION
## Summary

Fixes a 100% CPU busy-spin in the mbedTLS backend on non-blocking TLS sockets. A single misbehaving or slow TLS client can peg one CPU core per connection — e.g. opening a TCP connection to an HTTPS port and never completing the handshake spins a worker thread at 100% indefinitely. With a handful of such connections a server saturates every core. This is trivially reachable from the network, so it is effectively a low-effort DoS, and it is also the source of high-CPU reports against idle HTTPS keep-alive connections.

## Root cause

Non-blocking mbedTLS calls can repeatedly return `MBEDTLS_ERR_SSL_WANT_READ` / `WANT_WRITE` without making application-visible progress. Three code paths reacted by retrying immediately (or by waiting on the wrong socket event), which is what spun the CPU. Each now waits for the operation mbedTLS actually asked for, mirroring what the OpenSSL path (`sslize()`) already does:

- **Handshake** (`mbed_ssl_handshake`, `src/mod_mbedtls.inl`): the loop had no wait at all. It now waits with `mbedtls_net_poll()` for read- or write-readiness (matching `WANT_READ` / `WANT_WRITE`), with a finite timeout (`SOCKET_TIMEOUT_QUANTUM`) so it stays responsive to shutdown; `ASYNC_IN_PROGRESS` yields briefly instead of spinning. The accepted socket fd is passed in via the existing bio context.
- **Reads** (`pull_inner`, `src/civetweb.c`): instead of mapping `WANT_*` to "0 bytes" and returning immediately, it now waits with the existing `mg_poll()` on `POLLIN` / `POLLOUT`, bounded by the request timeout and integrated with the server stop flag.
- **Writes** (`push_inner`, `src/civetweb.c`): it already polled before retrying, but always for `POLLOUT`. When `mbedtls_ssl_write()` returns `WANT_READ` (e.g. during a renegotiation) the socket is almost always writable, so it spun; it now polls for the event mbedTLS requested.

No new configuration and no magic constants — the change is behaviour-only and confined to the mbedTLS paths.

## Testing

Built with the mbedTLS backend and exercised against a running server, sampling process CPU:

| Scenario | Before (busy-loop) | After (this PR) |
|----------------------------------------|--------------------|-----------------|
| 4 stalled TLS handshakes (8 s) | ~390% (4 cores) | <1% |
| 4 idle HTTPS keep-alive conns (8 s) | idle | idle |
| 20 concurrent HTTPS requests | 200 OK | 200 OK |
| Large HTTPS responses (write path) | 200 OK | 200 OK |
| Handshake that stalls 3 s then resumes | n/a | 200 OK |

The "resumes after stalling" case confirms the poll wait wakes and the handshake completes — it is an event wait, not a fixed delay.

The handshake spin needs no special tooling: **any plain-TCP client that connects to the HTTPS port and never sends a ClientHello makes the pre-fix server spin.** Open a few stalled connections with bash's `/dev/tcp` and sample the server process' CPU from `/proc` (cores summed). A self-contained reproduction/regression script using exactly this approach is published with the downstream report at pi-hole/FTL#2882; against the pre-fix code it measures hundreds of percent CPU and fails, against this change it stays near zero and passes.

The handshake and read spins are directly reproducible; the write spin requires a renegotiation that makes `mbedtls_ssl_write()` return `WANT_READ`, so it is addressed by inspection (wait for the requested event) and verified not to regress normal writes.

## Context

This is the upstream version of the fix being applied downstream in [pi-hole/FTL#2882](https://github.com/pi-hole/FTL/pull/2882), where it replaces a temporary backoff-sleep mitigation. Once this lands, the vendored copy can drop its local delta.
