### PR TITLE
pull_inner: wait for incomplete TLS records instead of a spurious timeout (fixes #1406)

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -6516,62 +6516,81 @@ pull_inner(FILE *fp,
 		int ssl_pending;
 		struct mg_pollfd pfd[2];
 		int pollres;
-		unsigned int num_sock = 1;
+		unsigned int num_sock;
 
-		if ((ssl_pending = SSL_pending(conn->ssl)) > 0) {
-			/* We already know there is no more data buffered in conn->buf
-			 * but there is more available in the SSL layer. So don't poll
-			 * conn->client.sock yet. */
-			if (ssl_pending > len) {
-				ssl_pending = len;
-			}
-			pollres = 1;
-		} else {
-			pfd[0].fd = conn->client.sock;
-			pfd[0].events = POLLIN;
+		for (;;) {
+			num_sock = 1;
+			if ((ssl_pending = SSL_pending(conn->ssl)) > 0) {
+				/* We already know there is no more data buffered in conn->buf
+				 * but there is more available in the SSL layer. So don't poll
+				 * conn->client.sock yet. */
+				if (ssl_pending > len) {
+					ssl_pending = len;
+				}
+				pollres = 1;
+			} else {
+				pfd[0].fd = conn->client.sock;
+				pfd[0].events = POLLIN;
 
-			if (conn->phys_ctx->context_type == CONTEXT_SERVER) {
-				pfd[num_sock].fd =
-				    conn->phys_ctx->thread_shutdown_notification_socket;
-				pfd[num_sock].events = POLLIN;
-				num_sock++;
-			}
+				if (conn->phys_ctx->context_type == CONTEXT_SERVER) {
+					pfd[num_sock].fd =
+					    conn->phys_ctx->thread_shutdown_notification_socket;
+					pfd[num_sock].events = POLLIN;
+					num_sock++;
+				}
 
-			pollres = mg_poll(pfd,
-			                  num_sock,
-			                  (int)(timeout * 1000.0),
-			                  &(conn->phys_ctx->stop_flag));
-			if (!STOP_FLAG_IS_ZERO(&conn->phys_ctx->stop_flag)) {
-				return -2;
-			}
-		}
-		if (pollres > 0) {
-			ERR_clear_error();
-			nread =
-			    SSL_read(conn->ssl, buf, (ssl_pending > 0) ? ssl_pending : len);
-			if (nread <= 0) {
-				err = SSL_get_error(conn->ssl, nread);
-				if ((err == SSL_ERROR_SYSCALL) && (nread == -1)) {
-					err = ERRNO;
-				} else if ((err == SSL_ERROR_WANT_READ)
-				           || (err == SSL_ERROR_WANT_WRITE)) {
-					nread = 0;
-				} else {
-					/* All errors should return -2 */
-					DEBUG_TRACE("SSL_read() failed, error %d", err);
-					ERR_clear_error();
+				pollres = mg_poll(pfd,
+				                  num_sock,
+				                  (int)(timeout * 1000.0),
+				                  &(conn->phys_ctx->stop_flag));
+				if (!STOP_FLAG_IS_ZERO(&conn->phys_ctx->stop_flag)) {
 					return -2;
 				}
-				ERR_clear_error();
-			} else {
-				err = 0;
 			}
-		} else if (pollres < 0) {
-			/* Error */
-			return -2;
-		} else {
-			/* pollres = 0 means timeout */
-			nread = 0;
+			if (pollres > 0) {
+				ERR_clear_error();
+				nread = SSL_read(conn->ssl,
+				                 buf,
+				                 (ssl_pending > 0) ? ssl_pending : len);
+				if (nread <= 0) {
+					err = SSL_get_error(conn->ssl, nread);
+					if ((err == SSL_ERROR_SYSCALL) && (nread == -1)) {
+						err = ERRNO;
+					} else if (err == SSL_ERROR_WANT_READ) {
+						/* The socket was readable but an incomplete TLS record
+						 * is still arriving, so no application data is ready
+						 * yet. SSL_read has already drained the available
+						 * socket bytes; re-poll for the remainder instead of
+						 * reporting a spurious idle timeout. Reporting -1 here
+						 * would, with websocket ping-pong enabled, be counted
+						 * as an unanswered ping and close a healthy connection
+						 * that is actively receiving a large (>16 KiB) frame. */
+						ERR_clear_error();
+						continue;
+					} else if (err == SSL_ERROR_WANT_WRITE) {
+						/* SSL_read wants to write (TLS renegotiation). The poll above
+						 * only waits for POLLIN, so do not re-poll here; keep the
+						 * original timeout-like return. Renegotiation is disabled
+						 * (SSL_OP_NO_RENEGOTIATION) and absent in TLS 1.3. */
+						nread = 0;
+					} else {
+						/* All errors should return -2 */
+						DEBUG_TRACE("SSL_read() failed, error %d", err);
+						ERR_clear_error();
+						return -2;
+					}
+					ERR_clear_error();
+				} else {
+					err = 0;
+				}
+			} else if (pollres < 0) {
+				/* Error */
+				return -2;
+			} else {
+				/* pollres = 0 means timeout */
+				nread = 0;
+			}
+			break;
 		}
 #endif
 


### PR DESCRIPTION
Fixes #1406.

### Problem

With `enable_websocket_ping_pong=yes`, a server-side WebSocket connection over TLS is
closed in the middle of receiving a normal data frame as soon as that frame's bytes arrive
split across several TCP segments — the normal case for any frame whose payload approaches
or exceeds one TLS record (≥ ~16 KiB), or on any lossy/segmented link. The client sees an
abrupt close (e.g. WinHTTP `ERROR_WINHTTP_CONNECTION_ERROR` 12030) and the
`mg_set_websocket_handler` data callback is never invoked for the frame. With
`enable_websocket_ping_pong=no` the exact same frame is delivered correctly.

### Root cause

`pull_inner()` returns `-1` both for a real poll timeout **and** for
`SSL_ERROR_WANT_READ` (an incomplete TLS record is still arriving — `SSL_read` has already
drained the available socket bytes but cannot yet return application data):

```c
} else if ((err == SSL_ERROR_WANT_READ)
           || (err == SSL_ERROR_WANT_WRITE)) {
    nread = 0;   /* falls through to the function's bottom `return -1` */
}
```

`read_websocket()` treats **every** `pull_inner() <= 0` in its refill branch as one elapsed
idle period and, with ping-pong enabled, sends a PING and increments `ping_count`. While a
large frame's first TLS record is still in flight, `SSL_read` returns `WANT_READ` on each
partial read, so `pull_inner` returns `-1` immediately and repeatedly (not after
`websocket_timeout_ms`). `ping_count` therefore exceeds `MG_MAX_UNANSWERED_PING` within
milliseconds and the healthy connection is closed before the frame is assembled.

This matches the long-standing comment already in `pull_inner()`:

```c
/* We need an additional wait loop around this, because in some cases
 * with TLS we may get data from the socket but not from SSL_read.
 * In this case we need to repeat at least once. */
```

…but that wait loop was never implemented. A clear tell that the PINGs are fired by the
`WANT_READ` spin and not by real timeouts: the failure time is **independent of
`websocket_timeout_ms`** (5 s and 30 s both close in well under a second).

### Fix

Implement the documented wait loop: on `WANT_READ`/`WANT_WRITE`, re-poll for the remainder
of the record instead of returning a spurious `-1`. `SSL_read` has already drained the
socket, so the re-`mg_poll()` blocks until genuinely new data (or a real timeout) — no
busy-spin. After this, `-1` means only a true idle timeout, so the ping cadence is correct.
The change is confined to the OpenSSL branch of `pull_inner()`; other read paths
(`pull_all` for HTTP bodies, etc.) loop on `pull_inner` already and are unaffected in
outcome.

### Verification

- Reproduced deterministically with a minimal civetweb WSS server and a stdlib-only Python
  client that delivers one large TLS record in small TCP chunks (full repro in #1406):
  buggy + ping-pong=yes → connection closed, callback never called; ping-pong=no → frame
  delivered; with this fix + ping-pong=yes → frame delivered (4 KiB … 256 KiB).
- civetweb's own unit-test suite built from the patched source passes **50/50**
  (OpenSSL 3.0), including the `test_request_handlers` WebSocket ws/wss exchange and all
  TLS/HTTPS cases.
- Validated end-to-end on an embedded device: a Windows WinHTTP/SChannel client uploading
  ≥16 KiB WebSocket frames (firmware upgrade) now succeeds where it previously failed.
