### PR TITLE
Restore a green CI: build fix (via #1392) + macOS OpenSSL 3.0

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -314,11 +314,12 @@ jobs:
           - os: macos-latest
             compiler: clang
             env:
-              NAME: Clang-OSX-Complete-NoLua-Release-OpenSSL_1_1_NoDynLoad
+              NAME: Clang-OSX-Complete-NoLua-Release-OpenSSL_3_0_NoDynLoad
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: NO
               OPENSSL_1_0: NO
-              OPENSSL_1_1: YES
+              OPENSSL_1_1: NO
+              OPENSSL_3_0: YES
               ENABLE_CXX: NO
               ENABLE_LUA_SHARED: NO
               C_STANDARD: auto
@@ -334,32 +335,6 @@ jobs:
               ENABLE_DUKTAPE: NO
               NO_CACHING: YES
               ALLOW_WARNINGS: YES
-              RUN_UNITTEST: 1
-
-          - os: macos-latest
-            compiler: clang
-            env:
-              NAME: OSX-Package_OpenSSL_1_1
-              BUILD_TYPE: Release
-              ENABLE_SSL_DYNAMIC_LOADING: YES
-              OPENSSL_1_0: NO
-              OPENSSL_1_1: YES
-              ENABLE_CXX: NO
-              ENABLE_LUA_SHARED: NO
-              C_STANDARD: auto
-              CXX_STANDARD: auto
-              BUILD_SHARED: NO
-              NO_FILES: NO
-              ENABLE_SSL: YES
-              NO_CGI: NO
-              ENABLE_IPV6: YES
-              ENABLE_WEBSOCKETS: YES
-              ENABLE_SERVER_STATS: NO
-              ENABLE_LUA: NO
-              ENABLE_DUKTAPE: NO
-              NO_CACHING: NO
-              ALLOW_WARNINGS: YES
-              MACOSX_PACKAGE: 1
               RUN_UNITTEST: 1
 
           - os: macos-latest
@@ -410,27 +385,10 @@ jobs:
             sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
             sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
 
-        - name: Set up OpenSSL 1.1 on modern MacOS
-          # OpenSSL 1.1 is installed by default, so we just need to set the paths
-          if: startsWith(matrix.os,'macos') && matrix.env.OPENSSL_1_1 == 'YES'
-          run: |
-            OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
-            LDFLAGS=-L${OPENSSL_ROOT_DIR}/lib
-            CFLAGS=-I${OPENSSL_ROOT_DIR}/include
-            ADDITIONAL_CMAKE_ARGS="-DCMAKE_SHARED_LINKER_FLAGS=${LDFLAGS} -DMAKE_C_FLAGS=${CFLAGS}"
-            PKG_CONFIG_PATH=${OPENSSL_ROOT_DIR}/lib/pkgconfig
-            DYLD_LIBRARY_PATH=${OPENSSL_ROOT_DIR}/lib
-            
-            echo "LDFLAGS=${LDFLAGS}" >> $GITHUB_ENV
-            echo "CFLAGS=${CFLAGS}" >> $GITHUB_ENV
-            echo "${OPENSSL_ROOT_DIR}/bin" >> $GITHUB_PATH
-            echo "ADDITIONAL_CMAKE_ARGS=${ADDITIONAL_CMAKE_ARGS}" >> $GITHUB_ENV
-            echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> $GITHUB_ENV
-            echo "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}" >> $GITHUB_ENV
-
         - name: Install OpenSSL 3.0 on modern MacOS
-          # OpenSSL 1.1 is installed by default, so we need to install 3.0 manually
-          if: startsWith(matrix.os,'macos') && matrix.env.OPENSSL_3_0 == 'YES'            
+          # OpenSSL 1.1 reached end of life and is no longer available via
+          # Homebrew, so the macOS SSL builds use OpenSSL 3.0, installed here.
+          if: startsWith(matrix.os,'macos') && matrix.env.OPENSSL_3_0 == 'YES'
           run: |
             brew install openssl@3.0
              

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -16056,7 +16056,7 @@ parse_port_string(const struct vec *vec, struct socket *so, int *ip_version)
 		size_t i;
 
 		/* Parse any suffix character(s) after the port number */
-		for (i = len; i < vec->len; i++) {
+		for (i = (size_t)len; i < vec->len; i++) {
 			unsigned char *opt = NULL;
 			switch (vec->ptr[i]) {
 			case 'o':
@@ -17774,7 +17774,8 @@ init_ssl_ctx_impl(struct mg_context *phys_ctx,
 #endif
 
 	protocol_ver = atoi(dom_ctx->config[SSL_PROTOCOL_VERSION]);
-	SSL_CTX_set_options(dom_ctx->ssl_ctx, ssl_get_protocol(protocol_ver));
+	SSL_CTX_set_options(dom_ctx->ssl_ctx,
+	                    (long unsigned)ssl_get_protocol(protocol_ver));
 	SSL_CTX_set_options(dom_ctx->ssl_ctx, SSL_OP_SINGLE_DH_USE);
 	SSL_CTX_set_options(dom_ctx->ssl_ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
 	SSL_CTX_set_options(dom_ctx->ssl_ctx,
@@ -19158,7 +19159,10 @@ get_message(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 static int
 get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 {
-	const char *h_zip, *h_chunk, *h_len;
+#if USE_ZLIB
+	const char *h_zip;
+#endif
+	const char *h_chunk, *h_len;
 
 	conn->connection_type =
 	    CONNECTION_TYPE_REQUEST; /* request (valid of not) */
@@ -19201,15 +19205,14 @@ get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 		conn->accept_gzip = 1;
 	}
 #endif
-   h_chunk = get_header(conn->request_info.http_headers,
-	                      conn->request_info.num_headers,
-	                      "Transfer-Encoding");
-   h_len = get_header(conn->request_info.http_headers,
-	                            conn->request_info.num_headers,
-	                            "Content-Length");
-	if (h_chunk != NULL)
-	    && mg_strcasecmp(cl, "identity")) {
-		if ((0!=mg_strcasecmp(cl, "chunked")) || (h_len!=NULL)) {
+	h_chunk = get_header(conn->request_info.http_headers,
+	                     conn->request_info.num_headers,
+	                     "Transfer-Encoding");
+	h_len = get_header(conn->request_info.http_headers,
+	                   conn->request_info.num_headers,
+	                   "Content-Length");
+	if ((h_chunk != NULL) && mg_strcasecmp(h_chunk, "identity")) {
+		if ((0 != mg_strcasecmp(h_chunk, "chunked")) || (h_len != NULL)) {
 			mg_snprintf(conn,
 			            NULL, /* No truncation check for ebuf */
 			            ebuf,
@@ -19224,8 +19227,8 @@ get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 	} else if (h_len != NULL) {
 		/* Request has content length set */
 		char *endptr = NULL;
-		conn->content_len = strtoll(cl, &endptr, 10);
-		if ((endptr == cl) || (conn->content_len < 0)) {
+		conn->content_len = strtoll(h_len, &endptr, 10);
+		if ((endptr == h_len) || (conn->content_len < 0)) {
 			mg_snprintf(conn,
 			            NULL, /* No truncation check for ebuf */
 			            ebuf,

--- a/src/handle_form.inl
+++ b/src/handle_form.inl
@@ -179,8 +179,13 @@ search_boundary(const char *buf,
 
 	/* We must do a binary search here, not a string search, since the
 	 * buffer may contain '\x00' bytes, if binary data is transferred. */
-	int clen = (int)buf_len - (int)boundary_len - boundary_start_len;
-	int i;
+	size_t clen;
+	size_t i;
+
+	if (buf_len < (boundary_len + boundary_start_len)) {
+		return NULL;
+	}
+	clen = buf_len - boundary_len - boundary_start_len;
 
 	for (i = 0; i <= clen; i++) {
 		if (!memcmp(buf + i, boundary_start, boundary_start_len)) {
@@ -429,7 +434,7 @@ mg_handle_form_request(struct mg_connection *conn,
 					 * been closed. */
 					all_data_read = (buf_fill == 0);
 				}
-				buf_fill += r;
+				buf_fill += (size_t)r;
 				buf[buf_fill] = 0;
 				if (buf_fill < 1) {
 					break;
@@ -556,7 +561,7 @@ mg_handle_form_request(struct mg_connection *conn,
 					        buf + (size_t)used,
 					        sizeof(buf) - (size_t)used);
 					next = buf;
-					buf_fill -= used;
+					buf_fill -= (size_t)used;
 					if (buf_fill < (sizeof(buf) - 1)) {
 
 						size_t to_read = sizeof(buf) - 1 - buf_fill;
@@ -579,7 +584,7 @@ mg_handle_form_request(struct mg_connection *conn,
 							 * read, or if the connection has been closed. */
 							all_data_read = (buf_fill == 0);
 						}
-						buf_fill += r;
+						buf_fill += (size_t)r;
 						buf[buf_fill] = 0;
 						if (buf_fill < 1) {
 							break;
@@ -619,7 +624,7 @@ mg_handle_form_request(struct mg_connection *conn,
 			/* Proceed to next entry */
 			used = next - buf;
 			memmove(buf, buf + (size_t)used, sizeof(buf) - (size_t)used);
-			buf_fill -= used;
+			buf_fill -= (size_t)used;
 		}
 
 		return field_count;
@@ -724,7 +729,7 @@ mg_handle_form_request(struct mg_connection *conn,
 				all_data_read = (buf_fill == 0);
 			}
 
-			buf_fill += r;
+			buf_fill += (size_t)r;
 			buf[buf_fill] = 0;
 			if (buf_fill < 1) {
 				/* No data */
@@ -948,7 +953,7 @@ mg_handle_form_request(struct mg_connection *conn,
 			/* If the boundary is already in the buffer, get the address,
 			 * otherwise next will be NULL. */
 			next = search_boundary(hbuf,
-			                       (size_t)((buf - hbuf) + buf_fill),
+			                       ((size_t)(buf - hbuf) + buf_fill),
 			                       boundary,
 			                       bl);
 
@@ -973,7 +978,7 @@ mg_handle_form_request(struct mg_connection *conn,
 			while (!next) {
 				/* Set "towrite" to the number of bytes available
 				 * in the buffer */
-				towrite = (size_t)(buf - hend + buf_fill);
+				towrite = ((size_t)(buf - hend) + buf_fill);
 
 				if (towrite < bl + 4) {
 					/* Not enough data stored. */
@@ -1047,7 +1052,7 @@ mg_handle_form_request(struct mg_connection *conn,
 				}
 				/* r==0 already handled, all_data_read is false here */
 
-				buf_fill += r;
+				buf_fill += (size_t)r;
 				buf[buf_fill] = 0;
 				/* buf_fill is at least 8 here */
 
@@ -1130,7 +1135,7 @@ mg_handle_form_request(struct mg_connection *conn,
 			if (next) {
 				used = next - buf + 2;
 				memmove(buf, buf + (size_t)used, sizeof(buf) - (size_t)used);
-				buf_fill -= used;
+				buf_fill -= (size_t)used;
 			} else {
 				buf_fill = 0;
 			}


### PR DESCRIPTION
Two commits, so this PR demonstrably restores a green CI:

1. **Build fix** - `master` does not compile (`get_request()` has an undeclared `cl` and a stray paren after the 588860e3 refactor). This is @yubiuser's fix from #1392, cherry-picked here with authorship preserved so the matrix can actually reach and pass the compile step. Happy to drop it once #1392 (or #1385/#1400) merges - it is included only so this PR can show green.

2. **CI fix** - even with the build fixed, the macOS jobs run `brew --prefix openssl@1.1`, which fails now that OpenSSL 1.1 is EOL and gone from Homebrew; with `fail-fast` that cancels the whole matrix before anything compiles. This moves the macOS jobs to OpenSSL 3.0 (the install path already exists), drops the redundant `OSX-Package_OpenSSL_1_1`, and removes the dead 1.1 setup step. Linux jobs use the system OpenSSL and are untouched.

The CI fix (commit 2) is the novel part; commit 1 is borrowed only to prove the two together turn CI green.
