### PR TITLE
Add PROXY protocol v2 support via a shared-secret option

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -314,11 +314,12 @@ jobs:
           - os: macos-latest
             compiler: clang
             env:
-              NAME: Clang-OSX-Complete-NoLua-Release-OpenSSL_1_1_NoDynLoad
+              NAME: Clang-OSX-Complete-NoLua-Release-OpenSSL_3_0_NoDynLoad
               BUILD_TYPE: Release
               ENABLE_SSL_DYNAMIC_LOADING: NO
               OPENSSL_1_0: NO
-              OPENSSL_1_1: YES
+              OPENSSL_1_1: NO
+              OPENSSL_3_0: YES
               ENABLE_CXX: NO
               ENABLE_LUA_SHARED: NO
               C_STANDARD: auto
@@ -334,32 +335,6 @@ jobs:
               ENABLE_DUKTAPE: NO
               NO_CACHING: YES
               ALLOW_WARNINGS: YES
-              RUN_UNITTEST: 1
-
-          - os: macos-latest
-            compiler: clang
-            env:
-              NAME: OSX-Package_OpenSSL_1_1
-              BUILD_TYPE: Release
-              ENABLE_SSL_DYNAMIC_LOADING: YES
-              OPENSSL_1_0: NO
-              OPENSSL_1_1: YES
-              ENABLE_CXX: NO
-              ENABLE_LUA_SHARED: NO
-              C_STANDARD: auto
-              CXX_STANDARD: auto
-              BUILD_SHARED: NO
-              NO_FILES: NO
-              ENABLE_SSL: YES
-              NO_CGI: NO
-              ENABLE_IPV6: YES
-              ENABLE_WEBSOCKETS: YES
-              ENABLE_SERVER_STATS: NO
-              ENABLE_LUA: NO
-              ENABLE_DUKTAPE: NO
-              NO_CACHING: NO
-              ALLOW_WARNINGS: YES
-              MACOSX_PACKAGE: 1
               RUN_UNITTEST: 1
 
           - os: macos-latest
@@ -410,27 +385,10 @@ jobs:
             sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
             sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
 
-        - name: Set up OpenSSL 1.1 on modern MacOS
-          # OpenSSL 1.1 is installed by default, so we just need to set the paths
-          if: startsWith(matrix.os,'macos') && matrix.env.OPENSSL_1_1 == 'YES'
-          run: |
-            OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
-            LDFLAGS=-L${OPENSSL_ROOT_DIR}/lib
-            CFLAGS=-I${OPENSSL_ROOT_DIR}/include
-            ADDITIONAL_CMAKE_ARGS="-DCMAKE_SHARED_LINKER_FLAGS=${LDFLAGS} -DMAKE_C_FLAGS=${CFLAGS}"
-            PKG_CONFIG_PATH=${OPENSSL_ROOT_DIR}/lib/pkgconfig
-            DYLD_LIBRARY_PATH=${OPENSSL_ROOT_DIR}/lib
-            
-            echo "LDFLAGS=${LDFLAGS}" >> $GITHUB_ENV
-            echo "CFLAGS=${CFLAGS}" >> $GITHUB_ENV
-            echo "${OPENSSL_ROOT_DIR}/bin" >> $GITHUB_PATH
-            echo "ADDITIONAL_CMAKE_ARGS=${ADDITIONAL_CMAKE_ARGS}" >> $GITHUB_ENV
-            echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> $GITHUB_ENV
-            echo "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}" >> $GITHUB_ENV
-
         - name: Install OpenSSL 3.0 on modern MacOS
-          # OpenSSL 1.1 is installed by default, so we need to install 3.0 manually
-          if: startsWith(matrix.os,'macos') && matrix.env.OPENSSL_3_0 == 'YES'            
+          # OpenSSL 1.1 reached end of life and is no longer available via
+          # Homebrew, so the macOS SSL builds use OpenSSL 3.0, installed here.
+          if: startsWith(matrix.os,'macos') && matrix.env.OPENSSL_3_0 == 'YES'
           run: |
             brew install openssl@3.0
              

--- a/docs/UserManual.md
+++ b/docs/UserManual.md
@@ -597,6 +597,21 @@ Comma separated list of URI=PATH pairs, specifying that given
 URIs must be protected with password files specified by PATH.
 All Paths must be full file paths.
 
+### proxy\_protocol\_secret
+When set to a non-empty value, civetweb parses a PROXY protocol version 2 header
+at the start of each new connection and, if the header carries a matching secret,
+replaces the connection's remote address (and its HTTPS status, taken from the
+standard SSL type-length-value) with the client the header announces. The secret
+is a hex-encoded shared key that a trusted upstream terminator or layer-4 proxy
+places in a custom type-length-value (type `0xE0`); it authenticates the header
+where source-address trust is not possible, e.g. a proxy on the loopback
+interface, a sidecar, or a shared host. With no secret configured (the default)
+the header is not parsed and normal requests are unaffected.
+
+The option value is a secret. civetweb never logs it, and an application that
+reads it back (for example via `mg_get_option`) should keep it out of its own
+logs and error messages.
+
 ### put\_delete\_auth\_file
 Passwords file for PUT and DELETE requests. Without a password file, it will not
 be possible to PUT new files to the server or DELETE existing ones. PUT and

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -16056,7 +16056,7 @@ parse_port_string(const struct vec *vec, struct socket *so, int *ip_version)
 		size_t i;
 
 		/* Parse any suffix character(s) after the port number */
-		for (i = len; i < vec->len; i++) {
+		for (i = (size_t)len; i < vec->len; i++) {
 			unsigned char *opt = NULL;
 			switch (vec->ptr[i]) {
 			case 'o':
@@ -17774,7 +17774,8 @@ init_ssl_ctx_impl(struct mg_context *phys_ctx,
 #endif
 
 	protocol_ver = atoi(dom_ctx->config[SSL_PROTOCOL_VERSION]);
-	SSL_CTX_set_options(dom_ctx->ssl_ctx, ssl_get_protocol(protocol_ver));
+	SSL_CTX_set_options(dom_ctx->ssl_ctx,
+	                    (long unsigned)ssl_get_protocol(protocol_ver));
 	SSL_CTX_set_options(dom_ctx->ssl_ctx, SSL_OP_SINGLE_DH_USE);
 	SSL_CTX_set_options(dom_ctx->ssl_ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
 	SSL_CTX_set_options(dom_ctx->ssl_ctx,
@@ -19158,7 +19159,10 @@ get_message(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 static int
 get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 {
-	const char *h_zip, *h_chunk, *h_len;
+#if USE_ZLIB
+	const char *h_zip;
+#endif
+	const char *h_chunk, *h_len;
 
 	conn->connection_type =
 	    CONNECTION_TYPE_REQUEST; /* request (valid of not) */
@@ -19201,15 +19205,14 @@ get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 		conn->accept_gzip = 1;
 	}
 #endif
-   h_chunk = get_header(conn->request_info.http_headers,
-	                      conn->request_info.num_headers,
-	                      "Transfer-Encoding");
-   h_len = get_header(conn->request_info.http_headers,
-	                            conn->request_info.num_headers,
-	                            "Content-Length");
-	if (h_chunk != NULL)
-	    && mg_strcasecmp(cl, "identity")) {
-		if ((0!=mg_strcasecmp(cl, "chunked")) || (h_len!=NULL)) {
+	h_chunk = get_header(conn->request_info.http_headers,
+	                     conn->request_info.num_headers,
+	                     "Transfer-Encoding");
+	h_len = get_header(conn->request_info.http_headers,
+	                   conn->request_info.num_headers,
+	                   "Content-Length");
+	if ((h_chunk != NULL) && mg_strcasecmp(h_chunk, "identity")) {
+		if ((0 != mg_strcasecmp(h_chunk, "chunked")) || (h_len != NULL)) {
 			mg_snprintf(conn,
 			            NULL, /* No truncation check for ebuf */
 			            ebuf,
@@ -19224,8 +19227,8 @@ get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 	} else if (h_len != NULL) {
 		/* Request has content length set */
 		char *endptr = NULL;
-		conn->content_len = strtoll(cl, &endptr, 10);
-		if ((endptr == cl) || (conn->content_len < 0)) {
+		conn->content_len = strtoll(h_len, &endptr, 10);
+		if ((endptr == h_len) || (conn->content_len < 0)) {
 			mg_snprintf(conn,
 			            NULL, /* No truncation check for ebuf */
 			            ebuf,

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -2103,6 +2103,7 @@ enum {
 #endif
 	ADDITIONAL_HEADER,
 	ALLOW_INDEX_SCRIPT_SUB_RES,
+	PROXY_PROTOCOL_SECRET,
 
 	NUM_OPTIONS
 };
@@ -2269,6 +2270,7 @@ static const struct mg_option config_options[] = {
 #endif
     {"additional_header", MG_CONFIG_TYPE_STRING_MULTILINE, NULL},
     {"allow_index_script_resource", MG_CONFIG_TYPE_BOOLEAN, "no"},
+    {"proxy_protocol_secret", MG_CONFIG_TYPE_STRING, NULL},
 
     {NULL, MG_CONFIG_TYPE_UNKNOWN, NULL}};
 
@@ -2605,6 +2607,8 @@ struct mg_connection {
 	char *path_info;          /* PATH_INFO part of the URL */
 
 	int must_close;       /* 1 if connection must be closed */
+	unsigned char proxy_is_ssl; /* PROXY v2 announced a TLS-terminated client
+	                             * (PP2_TYPE_SSL), so treat the request as HTTPS */
 	int accept_gzip;      /* 1 if gzip encoding is accepted */
 	int in_error_handler; /* 1 if in handler for user defined error
 	                       * pages */
@@ -20270,6 +20274,229 @@ produce_socket(struct mg_context *ctx, const struct socket *sp)
 #endif /* ALTERNATIVE_QUEUE */
 
 
+/* PROXY protocol v2 support.
+ *
+ * When the "proxy_protocol_secret" option is set, civetweb parses a PROXY
+ * protocol v2 header at the start of each new connection. The header is trusted
+ * only if it carries a custom TLV whose value equals the configured secret; a
+ * trusted header's announced client address (and TLS status, via the standard
+ * PP2_TYPE_SSL TLV) then replaces the transport peer. The shared secret lets a
+ * trusted upstream terminator or L4 proxy authenticate itself where source-
+ * address trust is not possible (a loopback backend, a sidecar, a shared host).
+ * With no secret configured the parser is a no-op, so normal requests are
+ * unaffected. */
+
+/* Custom PROXY v2 TLV (in the PP2_TYPE_MIN_CUSTOM 0xE0-0xEF range) carrying the
+ * shared secret that authenticates the header. */
+#define PP2_TYPE_PROXY_SECRET 0xE0
+/* Standard PROXY v2 TLV announcing the client spoke TLS to the proxy. */
+#define PP2_TYPE_SSL 0x20
+#define PP2_CLIENT_SSL 0x01
+
+static int
+proxy_v2_hexdigit(char c)
+{
+	if (c >= '0' && c <= '9') {
+		return c - '0';
+	}
+	if (c >= 'a' && c <= 'f') {
+		return c - 'a' + 10;
+	}
+	if (c >= 'A' && c <= 'F') {
+		return c - 'A' + 10;
+	}
+	return -1;
+}
+
+/* Decode the hex string `hex` into up to out_sz bytes of `out`. Returns the
+ * number of bytes decoded, or -1 on an odd length or a non-hex character. */
+static int
+proxy_v2_hex_decode(const char *hex, unsigned char *out, size_t out_sz)
+{
+	size_t n = 0;
+	while (hex[0] != '\0') {
+		int hi, lo;
+		if (hex[1] == '\0' || n >= out_sz) {
+			return -1;
+		}
+		hi = proxy_v2_hexdigit(hex[0]);
+		lo = proxy_v2_hexdigit(hex[1]);
+		if (hi < 0 || lo < 0) {
+			return -1;
+		}
+		out[n++] = (unsigned char)((hi << 4) | lo);
+		hex += 2;
+	}
+	return (int)n;
+}
+
+/* Parse a PROXY protocol v2 header on a fresh connection and, if it is trusted
+ * (carries the configured secret), replace the remote address with the real
+ * client the header announces. A no-op when the feature is disabled or no PROXY
+ * header is present. */
+static void
+parse_proxy_protocol_v2(struct mg_connection *conn)
+{
+	static const unsigned char sig[12] = {0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D,
+	                                      0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A};
+	const char *secret_hex;
+	unsigned char secret[64];
+	int secret_len;
+	struct pollfd pfd;
+	unsigned char hdr[16];
+	unsigned char buf[16 + 216]; /* 216 = largest v2 address block */
+	size_t addr_len, total, got, addr_size = 0;
+	int have;
+	const unsigned char *a;
+
+	/* Worker connection structs are reused across connections, so clear any
+	 * TLS-terminated marker from a previous connection before every early
+	 * return below - otherwise a later plaintext request on the same worker
+	 * would inherit a stale proxy_is_ssl and be mislabelled as HTTPS. */
+	conn->proxy_is_ssl = 0;
+
+	/* Opt-in: with no configured secret there is nothing to trust, so do not
+	 * touch the connection at all. */
+	secret_hex = (conn->dom_ctx != NULL)
+	                 ? conn->dom_ctx->config[PROXY_PROTOCOL_SECRET]
+	                 : NULL;
+	if (secret_hex == NULL || secret_hex[0] == '\0') {
+		return;
+	}
+	secret_len = proxy_v2_hex_decode(secret_hex, secret, sizeof(secret));
+	if (secret_len <= 0) {
+		return; /* misconfigured secret */
+	}
+
+	/* Peek the fixed 16-byte v2 header. Retry until 16 bytes are available, or
+	 * bail as soon as the available prefix already fails to match the
+	 * signature (i.e. this is a normal request, not a PROXY header). */
+	have = 0;
+	while (have < 16) {
+		int n;
+		pfd.fd = conn->client.sock;
+		pfd.events = POLLIN;
+		pfd.revents = 0;
+		if (poll(&pfd, 1, 1000) <= 0) {
+			return;
+		}
+		n = (int)recv(conn->client.sock, hdr, sizeof(hdr), MSG_PEEK);
+		if (n <= 0) {
+			return;
+		}
+		if (memcmp(hdr, sig, (n < 12) ? (size_t)n : (size_t)12) != 0) {
+			return;
+		}
+		/* MSG_PEEK does not consume, so poll() keeps reporting the same bytes
+		 * readable: if the peeked count did not grow since the last iteration
+		 * the peer has stalled mid-signature. Bail instead of spinning at 100%
+		 * CPU (a real proxy writes all 16 bytes in one segment). */
+		if (n <= have) {
+			return;
+		}
+		have = n;
+	}
+	if ((hdr[12] & 0xF0) != 0x20) {
+		return; /* not version 2 */
+	}
+
+	addr_len = ((size_t)hdr[14] << 8) | (size_t)hdr[15];
+	total = 16 + addr_len;
+	if (total > sizeof(buf)) {
+		return;
+	}
+
+	/* Consume the whole header for real so the HTTP request follows it. */
+	got = 0;
+	while (got < total) {
+		int n;
+		pfd.fd = conn->client.sock;
+		pfd.events = POLLIN;
+		pfd.revents = 0;
+		if (poll(&pfd, 1, 1000) <= 0) {
+			return;
+		}
+		n = (int)recv(conn->client.sock, buf + got, total - got, 0);
+		if (n <= 0) {
+			return;
+		}
+		got += (size_t)n;
+	}
+
+	/* Only the PROXY command (0x01) carries a real address; LOCAL (0x00) keeps
+	 * the original one. */
+	if ((hdr[12] & 0x0F) != 0x01) {
+		return;
+	}
+
+	a = buf + 16;
+	/* Note the address family/size but do NOT adopt the address yet - the header
+	 * must first prove it is trusted via the secret TLV below. */
+	if (hdr[13] == 0x11 && addr_len >= 12) { /* TCP over IPv4 */
+		addr_size = 12;
+	}
+#if defined(USE_IPV6)
+	else if (hdr[13] == 0x21 && addr_len >= 36) { /* TCP over IPv6 */
+		addr_size = 36;
+	}
+#endif
+	if (addr_size == 0) {
+		return; /* unsupported/short address block */
+	}
+
+	/* Walk the TLVs that follow the address block. Require the shared secret
+	 * (PP2_TYPE_PROXY_SECRET) before trusting the header, and note a
+	 * PP2_TYPE_SSL with PP2_CLIENT_SSL set (the client used TLS to the proxy). */
+	{
+		int token_ok = 0, ssl_flag = 0;
+		size_t off = addr_size;
+		while (off + 3 <= addr_len) {
+			const unsigned char t = a[off];
+			const size_t l = ((size_t)a[off + 1] << 8) | (size_t)a[off + 2];
+			off += 3;
+			if (off + l > addr_len) {
+				break;
+			}
+			if (t == PP2_TYPE_PROXY_SECRET && l == (size_t)secret_len) {
+				/* Constant-time compare so a co-resident process cannot time
+				 * byte-wise matching to recover the secret. */
+				unsigned char diff = 0;
+				size_t i;
+				for (i = 0; i < (size_t)secret_len; i++) {
+					diff |= (unsigned char)(a[off + i] ^ secret[i]);
+				}
+				if (diff == 0) {
+					token_ok = 1;
+				}
+			} else if (t == PP2_TYPE_SSL && l >= 1 && (a[off] & PP2_CLIENT_SSL)) {
+				ssl_flag = 1;
+			}
+			off += l;
+		}
+		if (!token_ok) {
+			return; /* secret missing or wrong - ignore the header */
+		}
+
+		/* Trusted: adopt the real client address and TLS status. */
+		if (hdr[13] == 0x11) { /* TCP over IPv4 */
+			memset(&conn->client.rsa, 0, sizeof(conn->client.rsa));
+			conn->client.rsa.sin.sin_family = AF_INET;
+			memcpy(&conn->client.rsa.sin.sin_addr, a, 4);
+			memcpy(&conn->client.rsa.sin.sin_port, a + 8, 2);
+		}
+#if defined(USE_IPV6)
+		else { /* TCP over IPv6 */
+			memset(&conn->client.rsa, 0, sizeof(conn->client.rsa));
+			conn->client.rsa.sin6.sin6_family = AF_INET6;
+			memcpy(&conn->client.rsa.sin6.sin6_addr, a, 16);
+			memcpy(&conn->client.rsa.sin6.sin6_port, a + 32, 2);
+		}
+#endif
+		conn->proxy_is_ssl = ssl_flag ? 1 : 0;
+	}
+}
+
+
 static void
 worker_thread_run(struct mg_connection *conn)
 {
@@ -20355,6 +20582,9 @@ worker_thread_run(struct mg_connection *conn)
 #endif
 		conn->conn_birth_time = time(NULL);
 
+		/* Adopt the real client from a PROXY protocol v2 header, if configured. */
+		parse_proxy_protocol_v2(conn);
+
 		/* Fill in IP, port info early so even if SSL setup below fails,
 		 * error handler would have the corresponding info.
 		 * Thanks to Johannes Winkelmann for the patch.
@@ -20377,7 +20607,7 @@ worker_thread_run(struct mg_connection *conn)
 		            (conn->client.is_ssl ? "SSL " : ""),
 		            conn->request_info.remote_addr);
 
-		conn->request_info.is_ssl = conn->client.is_ssl;
+		conn->request_info.is_ssl = conn->client.is_ssl || conn->proxy_is_ssl;
 
 		if (conn->client.is_ssl) {
 

--- a/src/handle_form.inl
+++ b/src/handle_form.inl
@@ -179,8 +179,13 @@ search_boundary(const char *buf,
 
 	/* We must do a binary search here, not a string search, since the
 	 * buffer may contain '\x00' bytes, if binary data is transferred. */
-	int clen = (int)buf_len - (int)boundary_len - boundary_start_len;
-	int i;
+	size_t clen;
+	size_t i;
+
+	if (buf_len < (boundary_len + boundary_start_len)) {
+		return NULL;
+	}
+	clen = buf_len - boundary_len - boundary_start_len;
 
 	for (i = 0; i <= clen; i++) {
 		if (!memcmp(buf + i, boundary_start, boundary_start_len)) {
@@ -429,7 +434,7 @@ mg_handle_form_request(struct mg_connection *conn,
 					 * been closed. */
 					all_data_read = (buf_fill == 0);
 				}
-				buf_fill += r;
+				buf_fill += (size_t)r;
 				buf[buf_fill] = 0;
 				if (buf_fill < 1) {
 					break;
@@ -556,7 +561,7 @@ mg_handle_form_request(struct mg_connection *conn,
 					        buf + (size_t)used,
 					        sizeof(buf) - (size_t)used);
 					next = buf;
-					buf_fill -= used;
+					buf_fill -= (size_t)used;
 					if (buf_fill < (sizeof(buf) - 1)) {
 
 						size_t to_read = sizeof(buf) - 1 - buf_fill;
@@ -579,7 +584,7 @@ mg_handle_form_request(struct mg_connection *conn,
 							 * read, or if the connection has been closed. */
 							all_data_read = (buf_fill == 0);
 						}
-						buf_fill += r;
+						buf_fill += (size_t)r;
 						buf[buf_fill] = 0;
 						if (buf_fill < 1) {
 							break;
@@ -619,7 +624,7 @@ mg_handle_form_request(struct mg_connection *conn,
 			/* Proceed to next entry */
 			used = next - buf;
 			memmove(buf, buf + (size_t)used, sizeof(buf) - (size_t)used);
-			buf_fill -= used;
+			buf_fill -= (size_t)used;
 		}
 
 		return field_count;
@@ -724,7 +729,7 @@ mg_handle_form_request(struct mg_connection *conn,
 				all_data_read = (buf_fill == 0);
 			}
 
-			buf_fill += r;
+			buf_fill += (size_t)r;
 			buf[buf_fill] = 0;
 			if (buf_fill < 1) {
 				/* No data */
@@ -948,7 +953,7 @@ mg_handle_form_request(struct mg_connection *conn,
 			/* If the boundary is already in the buffer, get the address,
 			 * otherwise next will be NULL. */
 			next = search_boundary(hbuf,
-			                       (size_t)((buf - hbuf) + buf_fill),
+			                       ((size_t)(buf - hbuf) + buf_fill),
 			                       boundary,
 			                       bl);
 
@@ -973,7 +978,7 @@ mg_handle_form_request(struct mg_connection *conn,
 			while (!next) {
 				/* Set "towrite" to the number of bytes available
 				 * in the buffer */
-				towrite = (size_t)(buf - hend + buf_fill);
+				towrite = ((size_t)(buf - hend) + buf_fill);
 
 				if (towrite < bl + 4) {
 					/* Not enough data stored. */
@@ -1047,7 +1052,7 @@ mg_handle_form_request(struct mg_connection *conn,
 				}
 				/* r==0 already handled, all_data_read is false here */
 
-				buf_fill += r;
+				buf_fill += (size_t)r;
 				buf[buf_fill] = 0;
 				/* buf_fill is at least 8 here */
 
@@ -1130,7 +1135,7 @@ mg_handle_form_request(struct mg_connection *conn,
 			if (next) {
 				used = next - buf + 2;
 				memmove(buf, buf + (size_t)used, sizeof(buf) - (size_t)used);
-				buf_fill -= used;
+				buf_fill -= (size_t)used;
 			} else {
 				buf_fill = 0;
 			}


### PR DESCRIPTION
Adds a `proxy_protocol_secret` configuration option. When set, civetweb parses a PROXY protocol version 2 header at the start of each new connection and, if the header carries a matching secret in a custom TLV (type `0xE0`), replaces the connection's remote address - and its HTTPS status, from the standard `PP2_TYPE_SSL` TLV - with the client the header announces. When unset (the default) the header is not parsed and existing behaviour is unchanged. Documented in `docs/UserManual.md`.

The shared secret lets a trusted upstream terminator or layer-4 proxy authenticate itself where source-address trust is not possible (a loopback backend, a container sidecar, a shared host). It is hex-encoded and compared in constant time; civetweb never logs it.

---

**Note on the first two commits:** this PR is stacked on #1412 so it can show a green CI. `master` currently does not compile (the `get_request()` refactor) and its macOS jobs can't install OpenSSL 1.1, so a feature PR on top of it would be red through no fault of its own. The two leading commits are #1412 (@yubiuser's build fix + a macOS `OpenSSL 1.1 -> 3.0` CI fix); once #1412 merges they drop out on rebase and only the PROXY-protocol commit remains. Review just the last commit.
