### PR TITLE
Serve custom error pages with their error status instead of 200

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -10590,7 +10590,14 @@ handle_static_file_request(struct mg_connection *conn,
 		return;
 	}
 	cl = (int64_t)filep->stat.size;
-	conn->status_code = 200;
+	/* A custom error page is delivered through this function as well, with
+	 * the error status already stored in conn->status_code by
+	 * mg_send_http_error_impl(). Overwriting it with 200 would tell the
+	 * client the request succeeded. handle_file_based_request() guards the
+	 * "not modified" path against the same problem. */
+	if (!conn->in_error_handler) {
+		conn->status_code = 200;
+	}
 	range[0] = '\0';
 
 #if defined(USE_ZLIB)
@@ -10659,7 +10666,7 @@ handle_static_file_request(struct mg_connection *conn,
 	/* If "Range" request was made: parse header, send only selected part
 	 * of the file. */
 	r1 = r2 = 0;
-	if ((range_hdr != NULL)
+	if ((!conn->in_error_handler) && (range_hdr != NULL)
 	    && ((n = parse_range_header(range_hdr, &r1, &r2)) > 0) && (r1 >= 0)
 	    && (r2 >= 0)) {
 		/* actually, range requests don't play well with a pre-gzipped

--- a/unittest/public_server.c
+++ b/unittest/public_server.c
@@ -4698,7 +4698,7 @@ START_TEST(test_error_handling)
 	client_ri = mg_get_response_info(client_conn);
 	ck_assert(client_ri != NULL);
 
-	ck_assert_int_eq(client_ri->status_code, 200);
+	ck_assert_int_eq(client_ri->status_code, 404);
 
 	client_res = (int)mg_read(client_conn, client_err, sizeof(client_err));
 	mg_close_connection(client_conn);
@@ -4730,7 +4730,7 @@ START_TEST(test_error_handling)
 	client_ri = mg_get_response_info(client_conn);
 	ck_assert(client_ri != NULL);
 
-	ck_assert_int_eq(client_ri->status_code, 200);
+	ck_assert_int_eq(client_ri->status_code, 404);
 
 	client_res = (int)mg_read(client_conn, client_err, sizeof(client_err));
 	mg_close_connection(client_conn);
@@ -4762,7 +4762,7 @@ START_TEST(test_error_handling)
 	client_ri = mg_get_response_info(client_conn);
 	ck_assert(client_ri != NULL);
 
-	ck_assert_int_eq(client_ri->status_code, 200);
+	ck_assert_int_eq(client_ri->status_code, 404);
 
 	client_res = (int)mg_read(client_conn, client_err, sizeof(client_err));
 	mg_close_connection(client_conn);
@@ -4788,7 +4788,7 @@ START_TEST(test_error_handling)
 	client_ri = mg_get_response_info(client_conn);
 	ck_assert(client_ri != NULL);
 
-	ck_assert_int_eq(client_ri->status_code, 200);
+	ck_assert_int_eq(client_ri->status_code, 400);
 
 	client_res = (int)mg_read(client_conn, client_err, sizeof(client_err));
 	mg_close_connection(client_conn);


### PR DESCRIPTION
When a custom error page is configured through `error_pages`, `mg_send_http_error_impl()` records the status in `conn->status_code` and then hands the file to `handle_file_based_request()`. `handle_static_file_request()` overwrites that with 200 unconditionally, so a client requesting a missing resource receives `200 OK` with the error page as the body. Everything that looks at the status line - caches, monitoring, `curl -f`, any client checking `response.ok` - is told the request succeeded.

`handle_file_based_request()` already guards the "not modified" path against this:

```c
if ((!conn->in_error_handler) && is_not_modified(conn, &file->stat)) {
```

so the flag is there for exactly this purpose, it is just not consulted before the status is overwritten. We use the same flag and keep the status the error handler recorded.

A `Range` header is ignored for the same reason. Without that, a failed request carrying one is answered with `206 Partial Content` plus a `Content-Range` describing a slice of the error page, which is *more* misleading than the plain 200, as the response then also claims to be part of the resource that was requested.

### Reproducing

```
document_root  /tmp/wwwroot
error_pages    /tmp/wwwroot/
index_files    index.html
```

with `error404.html` present in that directory:

| request | before | after |
| --- | --- | --- |
| `GET /missing.html` | `200 OK` | `404 Not Found` |
| `GET /missing-dir/` | `200 OK` | `404 Not Found` |
| `GET /missing.html` with `Range: bytes=0-9` | `206 Partial Content`, `Content-Range: bytes 0-9/52` | `404 Not Found`, no `Content-Range` |

In each case the body is the custom error page, both before and after - only the status line changes.

### Checked for regressions

| case | result |
| --- | --- |
| existing file | `200 OK`, unchanged |
| `Range: bytes=0-9` on an existing file | `206 Partial Content`, `Content-Range: bytes 0-9/48` |
| `If-None-Match` on an unchanged file | `304 Not Modified` |
| `If-None-Match` on a missing file | `404 Not Found` |
| `HEAD` on a missing file | `404 Not Found`, correct `Content-Length` |

### Note on CI

`master` does not currently compile (`src/civetweb.c`, `h_chunk`/`cl` in the request handling refactor), so CI on this PR will stay red until #1412 lands. I verified this change against `master` plus that build fix; the change itself is the two hunks below and does not touch that code.
