### PR TITLE
Store the context in the Lua registry regardless of USE_WEBSOCKET

### DIFF
--- a/src/mod_lua.inl
+++ b/src/mod_lua.inl
@@ -2889,13 +2889,11 @@ prepare_lua_environment(struct mg_context *ctx,
 #endif
 
 	/* Store context in the registry */
-#if defined(USE_WEBSOCKET)
 	if (ctx != NULL) {
 		lua_pushlightuserdata(L, (void *)&lua_regkey_ctx);
 		lua_pushlightuserdata(L, (void *)ctx);
 		lua_settable(L, LUA_REGISTRYINDEX);
 	}
-#endif /* USE_WEBSOCKET */
 	if (ws_conn_list != NULL) {
 		lua_pushlightuserdata(L, (void *)&lua_regkey_connlist);
 		lua_pushlightuserdata(L, (void *)ws_conn_list);


### PR DESCRIPTION
`20130037` wrapped the context store in `prepare_lua_environment()` in `#if defined(USE_WEBSOCKET)` while fixing the missing `struct lua_websock_data` declaration for builds without websocket support. The declaration fix was needed; the guard reaches too far.

`lua_regkey_ctx` is read back *unconditionally* by the ordinary Lua page helpers - `lsp_get_var()`, `lsp_get_mime_type()`, `lsp_get_cookie()`, `lsp_md5()` and the `mg_gc` handlers among them, none of which are websocket specific. Built without `USE_WEBSOCKET`, the key is therefore never set and each of those finds `NULL` where it expects the context.

Nothing fails to compile, which is what makes it awkward: a server built with Lua pages but without websockets only shows this at runtime.

The `ws_conn_list` store immediately below is deliberately left alone - it is naturally `NULL` when websockets are disabled, so it needs no guard either way.

Found while re-vendoring CivetWeb for Pi-hole, which builds with Lua and without websockets.
