### PR TITLE
Return on a form read error also without filesystem support

### DIFF
--- a/src/handle_form.inl
+++ b/src/handle_form.inl
@@ -562,14 +562,14 @@ mg_handle_form_request(struct mg_connection *conn,
 						size_t to_read = sizeof(buf) - 1 - buf_fill;
 						r = mg_read(conn, buf + buf_fill, to_read);
 						if ((r < 0) || ((r == 0) && all_data_read)) {
-#if !defined(NO_FILESYSTEMS)
 							/* read error */
+#if !defined(NO_FILESYSTEMS)
 							if (fstore.access.fp) {
 								mg_fclose(&fstore.access);
 								remove_bad_file(conn, path);
 							}
-							return -1;
 #endif /* NO_FILESYSTEMS */
+							return -1;
 						}
 						if (r == 0) {
 							/* TODO: Create a function to get "all_data_read"


### PR DESCRIPTION
In `mg_handle_form_request()` the read-error branch of the third `mg_read()` call has its `return -1` inside `#if !defined(NO_FILESYSTEMS)`, together with the `fstore` cleanup that genuinely needs it:

```c
r = mg_read(conn, buf + buf_fill, to_read);
if ((r < 0) || ((r == 0) && all_data_read)) {
#if !defined(NO_FILESYSTEMS)
	/* read error */
	if (fstore.access.fp) {
		mg_fclose(&fstore.access);
		remove_bad_file(conn, path);
	}
	return -1;
#endif /* NO_FILESYSTEMS */
}
```

Built with `NO_FILESYSTEMS` the entire branch compiles away, so a failed read falls through to `buf_fill += (size_t)r;` with a negative `r`. The cast wraps `buf_fill` around, and the `buf[buf_fill] = 0;` on the next line then writes far outside the 8 KB stack buffer - an out-of-bounds write reachable from a client that drops the connection mid-body.

Only the `fstore` cleanup depends on filesystem support, so the guard now covers just that and the `return -1` is unconditional. That is what the other two `mg_read()` error paths in the same function already do, which suggests this one was simply an oversight rather than intent.

### Testing

The default build is unaffected and compiles clean. A full `NO_FILESYSTEMS` build cannot be produced standalone - it also requires `NO_FILES` and user-supplied `mg_cry_internal_impl()` and `log_access()` implementations - so the conditional behaviour was confirmed by preprocessing the two shapes: with `NO_FILESYSTEMS` defined, `return -1` disappears before this change and survives after it.

Found by a static review while re-vendoring CivetWeb for Pi-hole. We do not build with `NO_FILESYSTEMS` ourselves, so this is reported rather than something we need.
