### PR TITLE
Return -1 on form read error even in NO_FILESYSTEMS builds

### DIFF
--- a/src/handle_form.inl
+++ b/src/handle_form.inl
@@ -568,8 +568,8 @@ mg_handle_form_request(struct mg_connection *conn,
 								mg_fclose(&fstore.access);
 								remove_bad_file(conn, path);
 							}
-							return -1;
 #endif /* NO_FILESYSTEMS */
+							return -1;
 						}
 						if (r == 0) {
 							/* TODO: Create a function to get "all_data_read"


### PR DESCRIPTION
In `mg_handle_form_request()`, the URL-encoded body reader has three `mg_read()` loops. Two of them return `-1` on a read error - `r < 0`, or `r == 0` once all data has been read - unconditionally. The middle loop (the one that runs after a key/value pair has been consumed and more data is pulled in) instead keeps its `return -1` inside the `#if !defined(NO_FILESYSTEMS)` block that guards the file cleanup:

```c
if ((r < 0) || ((r == 0) && all_data_read)) {
#if !defined(NO_FILESYSTEMS)
    /* read error */
    if (fstore.access.fp) {
        mg_fclose(&fstore.access);
        remove_bad_file(conn, path);
    }
    return -1;
#endif /* NO_FILESYSTEMS */
}
```

In a `NO_FILESYSTEMS` build that block compiles to nothing, so a read error is not caught. Control falls through to `buf_fill += r` with a negative `r`, which underflows the unsigned `buf_fill`, and the following `buf[buf_fill] = 0` is then an out-of-bounds write.

This moves the `return -1` out of the guard so it fires regardless of filesystem support, matching the other two read loops in the same function. Only the `mg_fclose()` / `remove_bad_file()` cleanup stays filesystem-specific.

No functional change for builds with filesystem support (the default).